### PR TITLE
Handle bowtie2 being a relative symlink

### DIFF
--- a/bowtie2
+++ b/bowtie2
@@ -39,7 +39,8 @@ my ($vol,$script_path,$prog);
 $prog = File::Spec->rel2abs( __FILE__ );
 
 while (-f $prog && -l $prog){
-    $prog = File::Spec->rel2abs(readlink($prog));   
+    my (undef, $dir, undef) = File::Spec->splitpath($prog);
+    $prog = File::Spec->rel2abs(readlink($prog), $dir);
 }
 
 ($vol,$script_path,$prog) 


### PR DESCRIPTION
Hi, Ben.

When bowtie2 is a relative symlink, I get the following error. This patch fixes the issue.

Cheers,
Shaun

``` sh
➜  /  cd /
➜  /  which bowtie2
/usr/local/bin/bowtie2
➜  /  ls -l /usr/local/bin/bowtie2
lrwxr-xr-x  1 sjackman  admin  35 Feb 16 21:11 /usr/local/bin/bowtie2 -> ../Cellar/bowtie2/2.2.0/bin/bowtie2
➜  /  bowtie2 --version
(ERR): Expected bowtie2 to be in same directory with bowtie2-align:
/Cellar/bowtie2/2.2.0/bin/
Exiting now ...
```
