### PR TITLE
Treat $^O eq 'MSWin32' as Windows, and assume everything else is *nix.

### DIFF
--- a/bowtie2
+++ b/bowtie2
@@ -45,7 +45,7 @@ while (-f $prog && -l $prog){
 
 ($vol,$script_path,$prog) 
                 = File::Spec->splitpath($prog);
-my $os_is_nix   = ($^O eq "linux") || ($^O eq "darwin");
+my $os_is_nix   = $^O ne "MSWin32";
 my $align_bin_s = $os_is_nix ? 'bowtie2-align-s' : 'bowtie2-align-s.exe'; 
 my $build_bin   = $os_is_nix ? 'bowtie2-build' : 'bowtie2-build.exe';               
 my $align_bin_l = $os_is_nix ? 'bowtie2-align-l' : 'bowtie2-align-l.exe'; 


### PR DESCRIPTION
Ran into the following error after attempting to run Bowtie 2.2.3 on FreeBSD 9.2:

```
$ bowtie2
(ERR): Expected bowtie2 to be in same directory with bowtie2-align:
/opt/bowtie/2.2.3/
Exiting now ...
```

On FreeBSD, the Perl <b>$^O</b> variable is 'freebsd', whereas the code assumes that everything that isn't 'linux' or 'darwin' is Windows.

Per http://www.perlmonks.org/?node_id=845088 , <b>$^O</b> is 'MSWin32' on all flavors of Windows; it would be more portable to assume everything that isn't Windows is *nix.