### PR TITLE
Adds LZ4 compression input/output

### DIFF
--- a/bowtie2
+++ b/bowtie2
@@ -182,7 +182,7 @@ for(my $i = 0; $i < scalar(@bt2_args); $i++) {
 		$bt2_args[$i] = undef;
 	}
 	for my $rarg ("un-conc", "al-conc", "un", "al") {
-		if($arg =~ /^--${rarg}$/ || $arg =~ /^--${rarg}-gz$/ || $arg =~ /^--${rarg}-bz2$/) {
+		if($arg =~ /^--${rarg}$/ || $arg =~ /^--${rarg}-gz$/ || $arg =~ /^--${rarg}-bz2$/ || $arg =~ /^--${rarg}-lz4$/) {
 			$bt2_args[$i] = undef;
 			if(scalar(@args) > 1 && $args[1] ne "") {
 				$read_fns{$rarg} = $args[1];
@@ -194,6 +194,7 @@ for(my $i = 0; $i < scalar(@bt2_args); $i++) {
 			$read_compress{$rarg} = "";
 			$read_compress{$rarg} = "gzip"  if $arg eq "--${rarg}-gz";
 			$read_compress{$rarg} = "bzip2" if $arg eq "--${rarg}-bz2";
+			$read_compress{$rarg} = "lz4" if $arg eq "--${rarg}-lz4";
 			last;
 		}
 	}
@@ -277,6 +278,9 @@ sub cat_file($$) {
 	} elsif($ifn =~ /\.bz2/) {
 		open($ifh, "bzip2 -dc $ifn |") ||
 			Fail("Could not open bzip2ed read file: $ifn \n");
+	} elsif($ifn =~ /\.lz4/) {
+		open($ifh, "lz4 -dc $ifn |") ||
+			Fail("Could not open lz4ed read file: $ifn \n");
 	} else {
 		open($ifh, $ifn) || Fail("Could not open read file: $ifn \n");
 	}
@@ -289,7 +293,7 @@ sub cat_file($$) {
 sub wrapInput($$$) {
 	my ($unps, $mate1s, $mate2s) = @_;
 	for my $fn (@$unps, @$mate1s, @$mate2s) {
-		return 1 if $fn =~ /\.gz$/ || $fn =~ /\.bz2$/;
+		return 1 if $fn =~ /\.gz$/ || $fn =~ /\.bz2$/ || $fn =~ /\.lz4$/;
 	}
 	return 0;
 }
@@ -491,8 +495,10 @@ if(defined($cap_out)) {
 				my ($redir1, $redir2) = (">$fn1", ">$fn2");
 				$redir1 = "| gzip -c $redir1"  if $read_compress{$i} eq "gzip";
 				$redir1 = "| bzip2 -c $redir1" if $read_compress{$i} eq "bzip2";
+				$redir1 = "| lz4 -c $redir1" if $read_compress{$i} eq "lz4";
 				$redir2 = "| gzip -c $redir2"  if $read_compress{$i} eq "gzip";
 				$redir2 = "| bzip2 -c $redir2" if $read_compress{$i} eq "bzip2";
+				$redir2 = "| lz4 -c $redir2" if $read_compress{$i} eq "lz4";
 				open($read_fhs{$i}{1}, $redir1) || Fail("Could not open --$i mate-1 output file '$fn1'\n");
 				open($read_fhs{$i}{2}, $redir2) || Fail("Could not open --$i mate-2 output file '$fn2'\n");
 				push @fhs_to_close, $read_fhs{$i}{1};
@@ -504,6 +510,7 @@ if(defined($cap_out)) {
 			    }
 				$redir = "| gzip -c $redir"  if $read_compress{$i} eq "gzip";
 				$redir = "| bzip2 -c $redir" if $read_compress{$i} eq "bzip2";
+				$redir = "| lz4 -c $redir" if $read_compress{$i} eq "lz4";
 				open($read_fhs{$i}, $redir) || Fail("Could not open --$i output file '$read_fns{$i}'\n");
 				push @fhs_to_close, $read_fhs{$i};
 			}


### PR DESCRIPTION
GZIP compression is quite CPU heavy and inefficient when you care mostly about speed. However Bowtie2 output can be large. LZ4 compression is compromise between speed and space efficiency. Please merge this patch that brings LZ4 compatibility to Bowtie2. Thanks.
