### PR TITLE
Add Missing Alias Script for `bowtie2-align`

### DIFF
--- a/bowtie2-align
+++ b/bowtie2-align
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+
+"""
+ Copyright 2014, Ben Langmead <langmea@cs.jhu.edu>
+
+ This file is part of Bowtie 2.
+
+ Bowtie 2 is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Bowtie 2 is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Bowtie 2.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+
+import os
+import imp
+import inspect
+import logging
+
+
+
+def main():
+    logging.basicConfig(level=logging.ERROR,
+                        format='%(levelname)s: %(message)s'
+                        )
+    align_bin_name      = "bowtie-align"
+    align_bin_s         = "bowtie2-align-s"
+    align_bin_l         = "bowtie2-align-l"
+    idx_ext_l             = '.1.bt2l'; 
+    idx_ext_s             = '.1.bt2'; 
+    curr_script           = os.path.realpath(inspect.getsourcefile(main))
+    ex_path               = os.path.dirname(curr_script)
+    align_bin_spec      = os.path.join(ex_path,align_bin_s)
+    bld                   = imp.load_source('bowtie2-build',os.path.join(ex_path,'bowtie2-build'))
+    options,arguments     = bld.build_args()
+
+    if '--verbose' in options:
+        logging.getLogger().setLevel(logging.INFO)
+        
+    if '--debug' in options:
+        align_bin_spec += '-debug'
+        align_bin_l += '-debug'
+        
+    if '--large-index' in options:
+        align_bin_spec = os.path.join(ex_path,align_bin_l)
+    elif '-x' in arguments:
+        if arguments.index('-x') + 1 < len(arguments):
+            idx_basename = arguments[arguments.index('-x') + 1]
+            large_idx_exists = os.path.exists(idx_basename + idx_ext_l)
+            small_idx_exists = os.path.exists(idx_basename + idx_ext_s)
+            if large_idx_exists and not small_idx_exists:
+                align_bin_spec = os.path.join(ex_path,align_bin_l)
+    
+    arguments[0] = align_bin_name
+    arguments.insert(1, 'basic-0')
+    arguments.insert(1, '--wrapper')
+    logging.info('Command: %s %s' %  (align_bin_spec,' '.join(arguments[1:])))
+    os.execv(align_bin_spec, arguments)        
+        
+        
+if __name__ == "__main__":
+    main()
+
+
+
+
+

--- a/doc/website/rhsidebar.ssi
+++ b/doc/website/rhsidebar.ssi
@@ -83,6 +83,16 @@
         </td>
       </tr>
 
+      <!-- GRCh38 -->
+      <tr>
+        <td>
+          <a href="ftp://ftp.ncbi.nlm.nih.gov/genbank/genomes/Eukaryotes/vertebrates_mammals/Homo_sapiens/GRCh38/seqs_for_alignment_pipelines/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.bowtie_index.tar.gz"><i>H. sapiens</i>, NCBI GRCh38</a>
+        </td>
+        <td align="right">
+          <b>3.5 GB</b>
+        </td>
+      </tr>
+
       <!-- mm10 -->
       <tr>
         <td>

--- a/pat.h
+++ b/pat.h
@@ -553,6 +553,49 @@ protected:
 	TReadId endid_; // index of read just read
 };
 
+class MockPatternSourcePerThread : public PatternSourcePerThread {
+
+public:
+
+	MockPatternSourcePerThread() : total_loops(MAX_LOOPS), seq_idx(0) { }
+
+	virtual ~MockPatternSourcePerThread() { }
+
+	/**
+	 * Read the next read pair.
+	 */
+	virtual bool nextReadPair(
+		bool& success,
+		bool& done,
+		bool& paired,
+		bool fixName)
+	{
+		return success;
+	}
+
+	Read& bufa()             { return buf1_;    }
+	Read& bufb()             { return buf2_;    }
+	const Read& bufa() const { return buf1_;    }
+	const Read& bufb() const { return buf2_;    }
+
+	TReadId       rdid()  const { return rdid_;  }
+	TReadId       endid() const { return endid_; }
+	virtual void  reset()       { rdid_ = endid_ = 0xffffffff;  }
+
+	/**
+	 * Return the length of mate 1 or mate 2.
+	 */
+	size_t length(int mate) const {
+		return (mate == 1) ? buf1_.length() : buf2_.length();
+	}
+
+protected:
+
+	const int MAX_LOOPS = 5000;
+	int total_loops; // Max total loops allowed
+	int seq_idx; // Next seq
+};
+
 /**
  * Abstract parent factory for PatternSourcePerThreads.
  */


### PR DESCRIPTION
It seems that this file is missing. As some other software depends on this script, I believe it is necessary to add this alias script as what are done for build and inspect.