### PR TITLE
make install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@
 # Makefile for bowtie, bowtie2-build, bowtie2-inspect
 #
 
+prefix = /usr/local
+bindir = $(prefix)/bin
+
 INC =
 GCC_PREFIX = $(shell dirname `which gcc`)
 GCC_SUFFIX =
@@ -434,6 +437,13 @@ doc/manual.html: MANUAL.markdown
 
 MANUAL: MANUAL.markdown
 	perl doc/strip_markdown.pl < $^ > $@
+
+.PHONY: install
+install: all
+	mkdir -p $(DESTDIR)$(bindir)
+	for file in $(BOWTIE2_BIN_LIST) bowtie2-inspect bowtie2-build bowtie2 ; do \
+		cp -f $$file $(DESTDIR)$(bindir) ; \
+	done
 
 .PHONY: clean
 clean:

--- a/doc/website/rhsidebar.ssi
+++ b/doc/website/rhsidebar.ssi
@@ -83,6 +83,16 @@
         </td>
       </tr>
 
+      <!-- GRCh38 -->
+      <tr>
+        <td>
+          <a href="ftp://ftp.ncbi.nlm.nih.gov/genbank/genomes/Eukaryotes/vertebrates_mammals/Homo_sapiens/GRCh38/seqs_for_alignment_pipelines/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.bowtie_index.tar.gz"><i>H. sapiens</i>, NCBI GRCh38</a>
+        </td>
+        <td align="right">
+          <b>3.5 GB</b>
+        </td>
+      </tr>
+
       <!-- mm10 -->
       <tr>
         <td>

--- a/ds.h
+++ b/ds.h
@@ -770,7 +770,7 @@ public:
 	void sortPortion(size_t begin, size_t num) {
 		assert_leq(begin+num, cur_);
 		if(num < 2) return;
-		std::sort(list_ + begin, list_ + begin + num);
+		std::stable_sort(list_ + begin, list_ + begin + num);
 	}
 	
 	/**

--- a/pat.h
+++ b/pat.h
@@ -553,6 +553,49 @@ protected:
 	TReadId endid_; // index of read just read
 };
 
+class MockPatternSourcePerThread : public PatternSourcePerThread {
+
+public:
+
+	MockPatternSourcePerThread() : total_loops(MAX_LOOPS), seq_idx(0) { }
+
+	virtual ~MockPatternSourcePerThread() { }
+
+	/**
+	 * Read the next read pair.
+	 */
+	virtual bool nextReadPair(
+		bool& success,
+		bool& done,
+		bool& paired,
+		bool fixName)
+	{
+		return success;
+	}
+
+	Read& bufa()             { return buf1_;    }
+	Read& bufb()             { return buf2_;    }
+	const Read& bufa() const { return buf1_;    }
+	const Read& bufb() const { return buf2_;    }
+
+	TReadId       rdid()  const { return rdid_;  }
+	TReadId       endid() const { return endid_; }
+	virtual void  reset()       { rdid_ = endid_ = 0xffffffff;  }
+
+	/**
+	 * Return the length of mate 1 or mate 2.
+	 */
+	size_t length(int mate) const {
+		return (mate == 1) ? buf1_.length() : buf2_.length();
+	}
+
+protected:
+
+	const int MAX_LOOPS = 5000;
+	int total_loops; // Max total loops allowed
+	int seq_idx; // Next seq
+};
+
 /**
  * Abstract parent factory for PatternSourcePerThreads.
  */


### PR DESCRIPTION
fixes #11

- adds standard variables prefix and bindir
- adds the install target that installs the standard executables to
  bindir

This allows to install as follows:

```
$ make DESTDIR=/tmp/bowtie install                                                                                                                         
mkdir -p /tmp/bowtie/usr/local/bin
for file in bowtie2-build-s bowtie2-build-l bowtie2-align-s bowtie2-align-l bowtie2-inspect-s bowtie2-inspect-l bowtie2-inspect bowtie2-build bowtie2 ; do \
        cp -f $file /tmp/bowtie/usr/local/bin ; \
done
$ tree /tmp/bowtie/
/tmp/bowtie/
└── usr
    └── local
        └── bin
            ├── bowtie2
            ├── bowtie2-align-l
            ├── bowtie2-align-s
            ├── bowtie2-build
            ├── bowtie2-build-l
            ├── bowtie2-build-s
            ├── bowtie2-inspect
            ├── bowtie2-inspect-l
            └── bowtie2-inspect-s

3 directories, 9 files
```

The default `prefix` is set to the standard `/usr/local` and can be changed as `DESTDIR` above.

These are the files I think that should be installed. Please let me know if there is something missing.