### PR TITLE
don't create zombies under race condition

### DIFF
--- a/bowtie2
+++ b/bowtie2
@@ -245,6 +245,7 @@ my @unps = ();
 my @mate1s = ();
 my @mate2s = ();
 my @to_delete = ();
+my @to_kill = ();
 my $temp_dir = "/tmp";
 my $bam_out = 0;
 my $ref_str = undef;
@@ -361,7 +362,10 @@ if(wrapInput(\@unps, \@mate1s, \@mate2s)) {
 			mkfifo($m1fn, 0700) || Fail("mkfifo($m1fn) failed.\n");
 		}
 		my $pid = 0;
-		$pid = fork() unless $no_pipes;
+		unless ($no_pipes) {
+			$pid = fork();
+			push @to_kill, $pid if $pid;
+		}
 		if($pid == 0) {
 			# Open named pipe 1 for writing
 			open(my $ofh, ">$m1fn") || Fail("Can't open '$m1fn' for writing\n");
@@ -378,7 +382,10 @@ if(wrapInput(\@unps, \@mate1s, \@mate2s)) {
 			mkfifo($m2fn, 0700) || Fail("mkfifo($m2fn) failed.\n");
 		}
 		$pid = 0;
-		$pid = fork() unless $no_pipes;
+		unless ($no_pipes) {
+			$pid = fork();
+			push @to_kill, $pid if $pid;
+		}
 		if($pid == 0) {
 			# Open named pipe 2 for writing
 			open(my $ofh, ">$m2fn") || Fail("Can't open '$m2fn' for writing.\n");
@@ -593,6 +600,7 @@ if(defined($cap_out)) {
 	$ret = system($cmd);
 }
 if(!$keep) { for(@to_delete) { unlink($_); } }
+kill 'HUP', @to_kill;
 
 if ($ret == -1) {
     Error("Failed to execute bowtie2-align: $!\n");

--- a/bowtie2
+++ b/bowtie2
@@ -407,7 +407,10 @@ if(wrapInput(\@unps, \@mate1s, \@mate2s)) {
 			mkfifo($ufn, 0700) || Fail("mkfifo($ufn) failed.\n");
 		}
 		my $pid = 0;
-		$pid = fork() unless $no_pipes;
+		unless ($no_pipes) {
+			$pid = fork();
+			push @to_kill, $pid if $pid;
+		}
 		if($pid == 0) {
 			# Open named pipe 2 for writing
 			open(my $ofh, ">$ufn") || Fail("Can't open '$ufn' for writing.\n");


### PR DESCRIPTION
Hello Ben,

We're observing bowtie zombies once in a while, and it seems that happens when bowtie-align fails in such a way that it doesn't try to open files passed in -1 and/or -2 parameters . Then, the feeder sub-processes hang forever in open(fifo) states.

To reproduce, replace $cmd to something else, f.ex. '/bin/false', before it gets executed.

The patch here kills the processes explicitly, and it seems to work fine.

Hope that makes sense,
Dmitry
