### PR TITLE
Quote -x parameter in bowtie2 wrapper.

### DIFF
--- a/bowtie2
+++ b/bowtie2
@@ -61,7 +61,8 @@ my @signame     = ();
 sub quote_params {
     my %params_2_quote = ('--rg' => 1, '--rg-id' => 1,
                           '-S' => 1, '-U' => 1,
-                          '-1' => 1, '-2' => 1
+                          '-1' => 1, '-2' => 1,
+                          '-x' => 1,
     );
     my $param_list = shift;
     my $quoting = 0;


### PR DESCRIPTION
Noticed the index filename was missing from quoted params in the bowtie2 wrapper.
