### PR TITLE
fixes bowtie2-build TypeError in PyPy

### DIFF
--- a/bowtie2-build
+++ b/bowtie2-build
@@ -80,7 +80,7 @@ def main():
     argv.appendleft('--wrapper')
     argv.appendleft(build_bin_spec)
     logging.info('Command: %s' % ' '.join(argv))
-    subprocess.call(argv)
+    subprocess.call(list(argv))
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This is a band-aid for an error encountered when at least one version of PyPy is the default version of Python:
```
bowtie2-build --version
Traceback (most recent call last):
  File "/home/travis/build/nellore/rail/src/bowtie2/bowtie2-build", line 86, in <module>
    main()
  File "/home/travis/build/nellore/rail/src/bowtie2/bowtie2-build", line 83, in main
    subprocess.call(argv)
  File "/opt/python/pypy2.7-5.8.0/lib-python/2.7/subprocess.py", line 168, in call
    return Popen(*popenargs, **kwargs).wait()
  File "/opt/python/pypy2.7-5.8.0/lib-python/2.7/subprocess.py", line 340, in __init__
    if args[1:] in (
TypeError: deque[:] is not supported
```