### PR TITLE
Add Travis build status.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,5 +1,7 @@
 Bowtie 2: http://bowtie-bio.sf.net/bowtie2
 
+[![Build Status](https://travis-ci.org/BenLangmead/bowtie2.svg?branch=master)](https://travis-ci.org/BenLangmead/bowtie2)
+
  - See AUTHORS for information about who wrote Bowtie 2 and its various
    components.
  - See LICENSE for license information.


### PR DESCRIPTION
Is it possible to add Travis CI build status badge image with the link to the Travis page?
Because I want to see the status easily.

You can check the modified `README.markdown` here.
https://github.com/junaruga/bowtie2/blob/feature/travis-image-badge/README.markdown

I renamed `README` to `README.markdown` to show the badge image, also considering `MANUAL.markdown` already exists.

About the position of the badge image, I referred Python's README file.
https://github.com/python/cpython

Thank you.
 