### PR TITLE
Allow for reproducible builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,8 +284,8 @@ both-sanitized: bowtie2-align-s-sanitized bowtie2-build-s-sanitized bowtie2-alig
 
 DEFS := -fno-strict-aliasing \
         -DBOWTIE2_VERSION="\"`cat VERSION`\"" \
-        -DBUILD_HOST="\"`hostname`\"" \
-        -DBUILD_TIME="\"`date`\"" \
+        -DBUILD_HOST="\"${HOSTNAME:-`hostname`}\"" \
+        -DBUILD_TIME="\"`date -u -r NEWS`\"" \
         -DCOMPILER_VERSION="\"`$(CXX) -v 2>&1 | tail -1`\"" \
         $(FILE_FLAGS) \
         $(PREF_DEF) \


### PR DESCRIPTION
* use NEWS file time instead of current time
* allow to override hostname via $HOSTNAME

See https://reproducible-builds.org/ for why this is good.

This date call works with GNU date and BSD date.

The alternative to this patch would be to drop both completely.


This PR was done while working on reproducible builds for openSUSE.