### PR TITLE
Support aarch64 (ARM 64-bit)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/simde"]
+	path = third_party/simde
+	url = https://github.com/nemequ/simde.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,28 @@ branches:
   - batch_parsing_output
   - blocked_input
   - bug_fixes
+matrix:
+  include:
+  # aarch64 - ARM 64-bit
+  - name: aarch64
+    install:
+    - docker run --rm --privileged multiarch/qemu-user-static:register --reset
+    - docker build --rm -t bowtie2 -f Dockerfile-aarch64 .
+    script:
+    # Ping stdout every 9 minutes or Travis kills build,
+    # as travis_wait does not show the command output while processing.
+    # https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
+    - |
+      while sleep 9m; do
+          echo "====[ $SECONDS seconds still running ]===="
+      done &
+    # Suppress warnings to see the Travis log easily.
+    - CXXFLAGS="-Wno-deprecated-declarations -Wno-misleading-indentation -Wno-narrowing -Wno-unused-function -Wno-unused-result"
+    # Run "make all" as "make allall simple-test" exceeds the Travis maximum
+    # time limit (50 minutes).
+    # Set POPCNT_CAPABILITY=0 to avoid a build error.
+    # NO_TBB=1 possibly saves the running time.
+    - docker run --rm -e CXXFLAGS="$CXXFLAGS" -e POPCNT_CAPABILITY=0 -t bowtie2 make -s -j 4 all
 script: make allall && make simple-test
 notifications:
   slack:

--- a/Dockerfile-aarch64
+++ b/Dockerfile-aarch64
@@ -1,0 +1,29 @@
+FROM multiarch/ubuntu-debootstrap:arm64-bionic
+
+WORKDIR /build
+COPY . .
+
+RUN uname -a
+RUN apt-get update -qq && \
+  apt-get install -yq --no-install-suggests --no-install-recommends \
+  build-essential \
+  ca-certificates \
+  gcc \
+  git \
+  g++ \
+  make \
+  software-properties-common \
+  zlib1g-dev
+RUN add-apt-repository -y universe && \
+  apt-get install -yq \
+  libtbb-dev
+
+# Patch to run with SIMD Everywhere (simde) for aarch64 case.
+# https://github.com/nemequ/simde
+# https://gitlab.com/arm-hpc/packages/wikis/packages/bowtie2
+RUN sed -i 's/__m/simde__m/g' aligner_*
+RUN sed -i 's/__m/simde__m/g' sse_util*
+RUN sed -i 's/_mm_/simde_mm_/g' aligner_*
+RUN sed -i 's/_mm_/simde_mm_/g' sse_util*
+
+CMD bash

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ CC ?= $(GCC_PREFIX)/gcc$(GCC_SUFFIX)
 CPP ?= $(GCC_PREFIX)/g++$(GCC_SUFFIX)
 CXX ?= $(CPP)
 CXXFLAGS += -std=c++98
+ifeq (aarch64,$(shell uname -m))
+	CXXFLAGS += -fopenmp-simd -DWITH_AARCH64
+	CPPFLAGS += -Ithird_party/simde
+endif
 
 HEADERS := $(wildcard *.h)
 BOWTIE_MM := 1
@@ -174,6 +178,9 @@ endif
 ifeq (amd64,$(shell uname -m))
 	BITS := 64
 endif
+ifeq (aarch64,$(shell uname -m))
+	BITS := 64
+endif
 # msys will always be 32 bit so look at the cpu arch instead.
 ifneq (,$(findstring AMD64,$(PROCESSOR_ARCHITEW6432)))
 	ifeq (1,$(MINGW))
@@ -185,9 +192,14 @@ ifeq (32,$(BITS))
 endif
 
 SSE_FLAG := -msse2
+M64_FLAG := -m64
+ifeq (aarch64,$(shell uname -m))
+	SSE_FLAG =
+	M64_FLAG =
+endif
 
-DEBUG_FLAGS    := -O0 -g3 -m64 $(SSE_FLAG)
-RELEASE_FLAGS  := -O3 -m64 $(SSE_FLAG) -funroll-loops -g3
+DEBUG_FLAGS    := -O0 -g3 $(M64_FLAG) $(SSE_FLAG)
+RELEASE_FLAGS  := -O3 $(M64_FLAG) $(SSE_FLAG) -funroll-loops -g3
 NOASSERT_FLAGS := -DNDEBUG
 FILE_FLAGS     := -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE
 DEBUG_DEFS     = -DCOMPILER_OPTIONS="\"$(DEBUG_FLAGS) $(CXXFLAGS)\""

--- a/aligner_sw.h
+++ b/aligner_sw.h
@@ -70,7 +70,11 @@
 #include <iostream>
 #include <limits>
 #include "threading.h"
+#ifdef WITH_AARCH64
+#include "simde/x86/sse2.h"
+#else
 #include <emmintrin.h>
+#endif
 #include "aligner_sw_common.h"
 #include "aligner_sw_nuc.h"
 #include "ds.h"

--- a/sse_util.h
+++ b/sse_util.h
@@ -24,7 +24,11 @@
 #include "ds.h"
 #include "limit.h"
 #include <iostream>
+#ifdef WITH_AARCH64
+#include "simde/x86/sse2.h"
+#else
 #include <emmintrin.h>
+#endif
 
 class EList_m128i {
 public:


### PR DESCRIPTION
Hello @BenLangmead . This PR is to support `bowtie2` to _aarch64_ (ARM 64-bit) environment.

Here is the passed Travis CI.
https://travis-ci.org/BenLangmead/bowtie2/builds/497898138

I am building some bio tools on the ARM environment.

I referred ARM development team's wiki document [1].

The way to run on different architecture has been used for `nanopolish` [2] and PostgreSQL binding [3]. (I contributed).

I also would like to inform you that Red Hat Enterprise Linux 8 started to support ARM 64-bit.
So, it might be a good timing for `bowtie2` to provide the aarch64.

https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8-beta/html-single/8.0_beta_release_notes/index#architectures

> The 64-bit ARM architecture

This also helps people to create `bowtie2` aarch64 deb package in Debian and Ubuntu project.
Right now there is only x86_64 package. [4][5]

I wish you will consider `bowtie2` to build on it.

Thank you.

[1] https://gitlab.com/arm-hpc/packages/wikis/packages/bowtie2
[2] nanopolish https://github.com/jts/nanopolish , Travis CI https://travis-ci.org/jts/nanopolish
[3] PostgreSQL Ruby binding: https://github.com/ged/ruby-pg , Travis CI https://travis-ci.org/ged/ruby-pg
[4] Debian bowtie2: https://tracker.debian.org/pkg/bowtie2
[5] Ubuntu bowtie2: https://packages.ubuntu.com/bionic/bowtie2
