### PR TITLE
Dropped -std=c++98 and improved portability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@
 # Makefile for bowtie, bowtie2-build, bowtie2-inspect
 #
 
-prefix := /usr/local
-bindir := $(prefix)/bin
+PREFIX := /usr/local
+bindir := $(PREFIX)/bin
 
 LDLIBS := -lz
 GCC_PREFIX := $(shell dirname `which gcc`)
@@ -30,7 +30,7 @@ GCC_SUFFIX :=
 CC ?= $(GCC_PREFIX)/gcc$(GCC_SUFFIX)
 CPP ?= $(GCC_PREFIX)/g++$(GCC_SUFFIX)
 CXX ?= $(CPP)
-CXXFLAGS += -std=c++98
+
 ifeq (aarch64,$(shell uname -m))
 	CXXFLAGS += -fopenmp-simd
 	CPPFLAGS += -Ithird_party/simde


### PR DESCRIPTION
Was having issues running bowtie2 across multiple distributions, so just implemented the changes suggested in https://github.com/BenLangmead/bowtie2/issues/248.

Was able to build using the following distributions:

- Ubuntu 19.04: clang 6.0, and gcc 8.3
- Fedora 30: clang 8.0, and gcc 9.0
- Debian 10: clang 6.0, and gcc 8.3