### PR TITLE
Refactor to make the Travis log more readable.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,11 @@ before_script:
   - echo CC=${CC} CXX=${CXX} NPROC=${NPROC}
   - $CC --version
   - $CXX --version
-script: make -j $NPROC allall && make simple-test
+script:
+  - set -e
+  - make -j $NPROC allall
+  - make simple-test
+  - set +e
 notifications:
   slack:
     secure: tfzT8N1fNV+oSV7tide9WrAj3ifs+LONJ3fCH1tUzexqrx23te4lE0oAj9C1cEMJ4evyRYwHNG8HZoLCOy8EfapqbWm6vgLIlkIBpeZ9E6f2jG6v0YuVDWWpqQC3qdGXCqWtHPjgs3i5OLsLwwQ/LItLoTqpBk2aYv+vGNs2F9g=

--- a/scripts/test/simple_tests.pl
+++ b/scripts/test/simple_tests.pl
@@ -4883,8 +4883,10 @@ foreach my $large_idx (undef,1) {
 				# it is best if we ignore them.
 				my $has_poison_reads = 0;
 
-				print $c->{name}." " if defined($c->{name});
-				print "(fw:".($fw ? 1 : 0).", sam:$sam)\n";
+				print "==== ";
+				print "".$c->{name}." " if defined($c->{name});
+				print "(fw:".($fw ? 1 : 0).", sam:$sam)";
+				print " ====\n";
 				my $mate1fw = 1;
 				my $mate2fw = 0;
 				$mate1fw = $c->{mate1fw} if defined($c->{mate1fw});


### PR DESCRIPTION
I am debuging seeing the Travis log now.

I have 2 suggestions to improve the Travis log's readability.

* Split the script command.
* Add a mark for each test to find it easily.

1st commit is inspired from https://github.com/travis-ci/travis-ci/issues/1066#issuecomment-32415710 .
This makes us to find the `make simple-test` easily in the log. You can see [this Travis log](https://travis-ci.org/github/junaruga/bowtie2/jobs/674615114#L220).

2nd commit is to add a mark to each test case header. It's like [this](https://travis-ci.org/github/junaruga/bowtie2/jobs/674615114#L376).
For people who will debug bowite2, current testing log is hard to find the target test when seeing the error.


