### PR TITLE
Fix to build with the given CXXFLAGS.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,18 +207,18 @@ else ifeq (amd64,$(shell uname -m))
 else ifeq (aarch64,$(shell uname -m))
   BITS := 64
   SSE_FLAG :=
-  CXXFLAGS := -fopenmp-simd
-  CPPFLAGS := -Ithird_party/simde
+  CXXFLAGS += -fopenmp-simd
+  CPPFLAGS += -Ithird_party/simde
 else ifeq (s390x,$(shell uname -m))
   BITS := 64
   SSE_FLAG :=
-  CXXFLAGS := -fopenmp-simd
-  CPPFLAGS := -Ithird_party/simde
+  CXXFLAGS += -fopenmp-simd
+  CPPFLAGS += -Ithird_party/simde
   SANITIZER_FLAGS :=
 else ifeq (ppc64le,$(shell uname -m))
   BITS := 64
   SSE_FLAG :=
-  CXXFLAGS := -fopenmp-simd
+  CXXFLAGS += -fopenmp-simd
   CPPFLAGS += -Ithird_party/simde
   SANITIZER_FLAGS :=
 endif


### PR DESCRIPTION
This PR is to build with the given `CXXFLAGS`.
Current `Makefile` ignore the given `CXXFLAGS` for only non-x86-64 architectures.

I am building with the following `CXXFLAGS`.

```
$ CXXFLAGS="-O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection" make
```
