### PR TITLE
Avoid repeated warning from header file

### DIFF
--- a/blockwise_sa.h
+++ b/blockwise_sa.h
@@ -219,10 +219,10 @@ public:
 		_built(false),
 		_base_fname(base_fname),
 		_bigEndian(currentlyBigEndian()),
-		_done(NULL)
 #ifdef WITH_TBB
-,thread_group_started(false)
+		thread_group_started(false),
 #endif
+		_done(NULL)
     { _randomSrc.init(__seed); reset(); }
 
     ~KarkkainenBlockwiseSA() throw()


### PR DESCRIPTION
This header file is used in a lot of _.cpp_ files so this warning appears numerous times during a build:

```
./blockwise_sa.h:222:3: warning: field '_done' will be initialized after field 'thread_group_started' [-Wreorder]
                _done(NULL)
                ^
```

Prevented by writing the initialisations in the right order, which also improves the formatting of the code as it no longer needs to fiddle the comma.