### PR TITLE
BUG: qupto overflows when there are >= 2**32 query sequences

### DIFF
--- a/bt2_dp.cpp
+++ b/bt2_dp.cpp
@@ -33,7 +33,7 @@ int gQuiet;                 // print nothing but the alignments
 static int sanityCheck;     // enable expensive sanity checks
 static int seed;            // srandom() seed
 static bool showVersion;    // just print version and quit?
-static uint32_t qUpto;      // max # of queries to read
+static uint64_t qUpto;      // max # of queries to read
 static int nthreads;        // number of pthreads operating concurrently
 static uint32_t skipReads;  // # reads/read pairs to skip
 int gGapBarrier;            // # diags on top/bot only to be entered diagonally
@@ -67,7 +67,7 @@ static void resetOptions() {
 	sanityCheck				= 0;  // enable expensive sanity checks
 	seed					= 0; // srandom() seed
 	showVersion				= false; // just print version and quit?
-	qUpto					= 0xffffffff; // max # of queries to read
+	qUpto					= 0xffffffffffffffff; // max # of queries to read
 	nthreads				= 1;     // number of pthreads operating concurrently
 	skipReads				= 0;     // # reads/read pairs to skip
 	gGapBarrier				= 4;     // disallow gaps within this many chars of either end of alignment

--- a/bt2_search.cpp
+++ b/bt2_search.cpp
@@ -99,7 +99,7 @@ static bool metricsPerRead; // report a metrics tuple for every read
 static bool allHits;      // for multihits, report just one
 static bool showVersion;  // just print version and quit?
 static int ipause;        // pause before maching?
-static uint32_t qUpto;    // max # of queries to read
+static uint64_t qUpto;    // max # of queries to read
 static int gTrim5;        // amount to trim from 5' end
 static int gTrim3;        // amount to trim from 3' end
 static pair<short, size_t> trimTo; // trim reads exceeding given length from either 3' or 5'-end
@@ -298,7 +298,7 @@ static void resetOptions() {
 	allHits					= false; // for multihits, report just one
 	showVersion				= false; // just print version and quit?
 	ipause					= 0; // pause before maching?
-	qUpto					= 0xffffffff; // max # of queries to read
+	qUpto					= 0xffffffffffffffff; // max # of queries to read
 	gTrim5					= 0; // amount to trim from 5' end
 	gTrim3					= 0; // amount to trim from 3' end
 	trimTo = pair<short, size_t>(5, 0); // default: don't do any trimming

--- a/pat.h
+++ b/pat.h
@@ -77,7 +77,7 @@ struct PatternParams {
 		int sampleLen_,
 		int sampleFreq_,
 		size_t skip_,
-		size_t upto_,
+		uint64_t upto_,
 		int nthreads_,
 		bool fixName_,
 		bool preserve_tags_,
@@ -116,7 +116,7 @@ struct PatternParams {
 	int sampleLen;		  // length of sampled reads for FastaContinuous...
 	int sampleFreq;		  // frequency of sampled reads for FastaContinuous...
 	size_t skip;		  // skip the first 'skip' patterns
-	size_t upto;		  // max number of queries to read
+    uint64_t upto;		  // max number of queries to read
 	int nthreads;		  // number of threads for locking
 	bool fixName;		  //
 	bool preserve_tags;       // keep existing tags when aligning BAM files


### PR DESCRIPTION
This should fix #311.

# Summary
`qUpto` was defined as `uint32_t` with a default max number of queries set at `0xffffffff`. When provided with an input file with >= 2^32 queries, the reads at and beyond 2^32 were silently discarded. This patch modifies the type to `uint64_t` and updates the default maximum to `0xffffffffffffffff`. 

# Importance
The former default was added approximately 10 years ago, which made sense with the generation of sequencing instruments at the time. However, this default presents an issue for Illumina NovaSeq platforms, as they can produce [billions](https://www.illumina.com/systems/sequencing-platforms/novaseq/specifications.html) of sequencing reads per lane. At the moment, users must partition input query files into multiple sets to work around this. However, the current behavior is silent, so users may not know they are hitting the read limit. Updating the type and default seemed like the path of least resistance, and would allow users to avoid chunking large input files.

# Detail
FASTA files containing exactly 2^32 sequences (4294967296), and 2^32+1 sequences (4294967297) were constructed with an incrementing integer identifier, and a trivial sequence ("AA"). The output below will focus on the stats as provided to stderr, but a brief check of the output `.sam` files shows the sequences at and beyond 2^32 are not included in the output.

Using 2^32 queries, the output will indicate that 2^32 - 1 reads exist: 

```bash
$ cat sub_6Ktist.e1381896
ModuleCmd_Load.c(204):ERROR:105: Unable to locate a modulefile for 'git_2.9.3'
4294967295 reads; of these:
  4294967295 (100.00%) were unpaired; of these:
    0 (0.00%) aligned 0 times
    4294967295 (100.00%) aligned exactly 1 time
    0 (0.00%) aligned >1 times
100.00% overall alignment rate
```

If the input contains 2^32 + 1 queries, the output will still that show 2^32 - 1 reads exist:

```bash
$ cat sub_Bn22gc.e1381897
ModuleCmd_Load.c(204):ERROR:105: Unable to locate a modulefile for 'git_2.9.3'
4294967295 reads; of these:
  4294967295 (100.00%) were unpaired; of these:
    0 (0.00%) aligned 0 times
    4294967295 (100.00%) aligned exactly 1 time
    0 (0.00%) aligned >1 times
100.00% overall alignment rate
```

Both of the above executions of bowtie2 relied on `master`, specifically 819afa7f51c52313bd5eaad82227c43df08c94cf:

```bash
$ ./bowtie2 --version
/home/mcdonadt/bowtie2/bowtie2-vanilla/bowtie2-align-s version 2.4.2
64-bit
Built on
Tue Sep 15 00:13:40 UTC 2020
Compiler: gcc version 7.3.0 (crosstool-NG 1.23.0.450-d54ae)
Options: -O3 -msse2 -funroll-loops -g3 -fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem /home/mcdonadt/miniconda3/envs/qiime2-2020.2/include -DPOPCNT_CAPABILITY -DWITH_TBB -std=c++11 -DNO_SPINLOCK -DWITH_QUEUELOCK=1
Sizeof {int, long, long long, void*, size_t, off_t}: {4, 8, 8, 8, 8, 8}
```

Output using this PR reports the correct number of reads. For simplicity, am only showing the result for 2^32+1 queries:

```bash
$ cat sub_pQzw9i.e1381898
ModuleCmd_Load.c(204):ERROR:105: Unable to locate a modulefile for 'git_2.9.3'
4294967297 reads; of these:
  4294967297 (100.00%) were unpaired; of these:
    0 (0.00%) aligned 0 times
    4294967297 (100.00%) aligned exactly 1 time
    0 (0.00%) aligned >1 times
100.00% overall alignment rate
```

The following command structure was used for all runs. The `db` used contained 4 artificial sequences that assured the mock input would match for simplicity. 

```
bowtie2 -p 1 -x ${db} \
    -f ${queries} \
    -S ${output} \
    --seed 42 \
    --very-sensitive \
    -k 1 \
    --np 1 \
    --mp "1,1" \
    --rdg "0,1" \
    --rfg "0,1" \
    --no-head \
    --no-unal
```

# Notes
A simple `.c` program was created to produce the input fasta files, with some supporting bash scripts to run bowtie2. All scripts etc can be readily shared if that would be useful to evaluate this PR. Due to the size of the problem, it would be preferable to not share the fasta's (each ~60GB) or output .sam files (each ~399GB). 