### PR TITLE
Add prefetch commands to speedup countUpToEx

### DIFF
--- a/aligner_seed.cpp
+++ b/aligner_seed.cpp
@@ -1533,9 +1533,9 @@ SeedAligner::searchSeedBi(
 		off = s.steps[i];
 		bool ltr = off > 0;
 		const Ebwt* ebwt = ltr ? ebwtBw_ : ebwtFw_;
-                assert(ebwt != NULL);
-                off = abs(off)-1;
-                __builtin_prefetch(&((*seq_)[off]));
+		assert(ebwt != NULL);
+		off = abs(off)-1;
+		__builtin_prefetch(&((*seq_)[off]));
 		if(ltr) {
 			tp[0] = tp[1] = tp[2] = tp[3] = topf;
 			bp[0] = bp[1] = bp[2] = bp[3] = botf;
@@ -1557,17 +1557,17 @@ SeedAligner::searchSeedBi(
 		}
 		TIndexOffU *tf = ltr ? tp : t, *tb = ltr ? t : tp;
 		TIndexOffU *bf = ltr ? bp : b, *bb = ltr ? b : bp;
-                int c = (*seq_)[off];  assert_range(0, 4, c);
+		int c = (*seq_)[off];  assert_range(0, 4, c);
 		// not 100% sure we need it, but redundant prefetches are not dangerous
 		// and helps in the average case
-                prefetchNextLocsBi(tf[c], bf[c], tb[c], bb[c], i+1);
+		prefetchNextLocsBi(tf[c], bf[c], tb[c], bb[c], i+1);
 
 		//
 		bool leaveZone = s.zones[i].first < 0;
 		//bool leaveZoneIns = zones_[i].second < 0;
 		Constraint& cons    = *zones[abs(s.zones[i].first)];
 		//Constraint& insCons = *zones[abs(s.zones[i].second)];
-                int q = (*qual_)[off];
+		int q = (*qual_)[off];
 		// Is it legal for us to advance on characters other than 'c'?
 		if(!(cons.mustMatch() && !overall.mustMatch()) || c == 4) {
 			// There may be legal edits

--- a/aligner_seed.cpp
+++ b/aligner_seed.cpp
@@ -1514,7 +1514,6 @@ SeedAligner::searchSeedBi(
 			}
 			return true;
 		}
-                prefetchNextLocsBi(topf, botf, topb, botb, step);
 		nextLocsBi(tloc, bloc, topf, botf, topb, botb, step);
 		assert(tloc.valid());
 	} else assert(prevEdit != NULL);

--- a/aligner_seed.cpp
+++ b/aligner_seed.cpp
@@ -1107,8 +1107,6 @@ SeedAligner::searchSeedBi() {
 
 inline void
 SeedAligner::prefetchNextLocsBi(
-        SideLocus& tloc,            // top locus
-        SideLocus& bloc,            // bot locus
         TIndexOffU topf,              // top in BWT
         TIndexOffU botf,              // bot in BWT
         TIndexOffU topb,              // top in BWT'
@@ -1116,27 +1114,29 @@ SeedAligner::prefetchNextLocsBi(
         int step                    // step to get ready for
         )
 {
-        if(step == (int)s_->steps.size()) return; // no more steps!
-        // Which direction are we going in next?
-        if(s_->steps[step] > 0) {
-                // Left to right; use BWT'
-                if(botb - topb == 1) {
-                        // Already down to 1 row; just init top locus
-                        tloc.prefetchFromRow(topb, ebwtBw_->eh(), ebwtBw_->ebwt());
-                } else {
-                        SideLocus::prefetchFromTopBot(
-                                topb, botb, ebwtBw_->eh(), ebwtBw_->ebwt(), tloc, bloc);
-                }
-        } else {
-                // Right to left; use BWT
-                if(botf - topf == 1) {
-                        // Already down to 1 row; just init top locus
-                        tloc.prefetchFromRow(topf, ebwtFw_->eh(), ebwtFw_->ebwt());
-                } else {
-                        SideLocus::prefetchFromTopBot(
-                                topf, botf, ebwtFw_->eh(), ebwtFw_->ebwt(), tloc, bloc);
-                }
-        }
+	if(step == (int)s_->steps.size()) return; // no more steps!
+	// Which direction are we going in next?
+	if(s_->steps[step] > 0) {
+		// Left to right; use BWT'
+		if(botb - topb == 1) {
+			// Already down to 1 row; just init top locus
+			SideLocus::prefetchFromRow(
+				topb, ebwtBw_->eh(), ebwtBw_->ebwt());
+		} else {
+			SideLocus::prefetchFromTopBot(
+				topb, botb, ebwtBw_->eh(), ebwtBw_->ebwt());
+		}
+	} else {
+		// Right to left; use BWT
+		if(botf - topf == 1) {
+			// Already down to 1 row; just init top locus
+			SideLocus::prefetchFromRow(
+				topf, ebwtFw_->eh(), ebwtFw_->ebwt());
+		} else {
+			SideLocus::prefetchFromTopBot(
+				topf, botf, ebwtFw_->eh(), ebwtFw_->ebwt());
+		}
+	}
 }
 
 /**
@@ -1514,7 +1514,7 @@ SeedAligner::searchSeedBi(
 			}
 			return true;
 		}
-                prefetchNextLocsBi(tloc, bloc, topf, botf, topb, botb, step);
+                prefetchNextLocsBi(topf, botf, topb, botb, step);
 		nextLocsBi(tloc, bloc, topf, botf, topb, botb, step);
 		assert(tloc.valid());
 	} else assert(prevEdit != NULL);
@@ -1561,7 +1561,7 @@ SeedAligner::searchSeedBi(
                 int c = (*seq_)[off];  assert_range(0, 4, c);
 		// not 100% sure we need it, but redundant prefetches are not dangerous
 		// and helps in the average case
-                prefetchNextLocsBi(tloc, bloc, tf[c], bf[c], tb[c], bb[c], i+1);
+                prefetchNextLocsBi(tf[c], bf[c], tb[c], bb[c], i+1);
 
 		//
 		bool leaveZone = s.zones[i].first < 0;

--- a/aligner_seed.cpp
+++ b/aligner_seed.cpp
@@ -1105,6 +1105,40 @@ SeedAligner::searchSeedBi() {
 		NULL);
 }
 
+inline void
+SeedAligner::prefetchNextLocsBi(
+        SideLocus& tloc,            // top locus
+        SideLocus& bloc,            // bot locus
+        TIndexOffU topf,              // top in BWT
+        TIndexOffU botf,              // bot in BWT
+        TIndexOffU topb,              // top in BWT'
+        TIndexOffU botb,              // bot in BWT'
+        int step                    // step to get ready for
+        )
+{
+        if(step == (int)s_->steps.size()) return; // no more steps!
+        // Which direction are we going in next?
+        if(s_->steps[step] > 0) {
+                // Left to right; use BWT'
+                if(botb - topb == 1) {
+                        // Already down to 1 row; just init top locus
+                        tloc.prefetchFromRow(topb, ebwtBw_->eh(), ebwtBw_->ebwt());
+                } else {
+                        SideLocus::prefetchFromTopBot(
+                                topb, botb, ebwtBw_->eh(), ebwtBw_->ebwt(), tloc, bloc);
+                }
+        } else {
+                // Right to left; use BWT
+                if(botf - topf == 1) {
+                        // Already down to 1 row; just init top locus
+                        tloc.prefetchFromRow(topf, ebwtFw_->eh(), ebwtFw_->ebwt());
+                } else {
+                        SideLocus::prefetchFromTopBot(
+                                topf, botf, ebwtFw_->eh(), ebwtFw_->ebwt(), tloc, bloc);
+                }
+        }
+}
+
 /**
  * Get tloc, bloc ready for the next step.  If the new range is under
  * the ceiling.
@@ -1480,6 +1514,7 @@ SeedAligner::searchSeedBi(
 			}
 			return true;
 		}
+                prefetchNextLocsBi(tloc, bloc, topf, botf, topb, botb, step);
 		nextLocsBi(tloc, bloc, topf, botf, topb, botb, step);
 		assert(tloc.valid());
 	} else assert(prevEdit != NULL);
@@ -1499,7 +1534,9 @@ SeedAligner::searchSeedBi(
 		off = s.steps[i];
 		bool ltr = off > 0;
 		const Ebwt* ebwt = ltr ? ebwtBw_ : ebwtFw_;
-		assert(ebwt != NULL);
+                assert(ebwt != NULL);
+                off = abs(off)-1;
+                __builtin_prefetch(&((*seq_)[off]));
 		if(ltr) {
 			tp[0] = tp[1] = tp[2] = tp[3] = topf;
 			bp[0] = bp[1] = bp[2] = bp[3] = botf;
@@ -1521,14 +1558,17 @@ SeedAligner::searchSeedBi(
 		}
 		TIndexOffU *tf = ltr ? tp : t, *tb = ltr ? t : tp;
 		TIndexOffU *bf = ltr ? bp : b, *bb = ltr ? b : bp;
-		off = abs(off)-1;
+                int c = (*seq_)[off];  assert_range(0, 4, c);
+		// not 100% sure we need it, but redundant prefetches are not dangerous
+		// and helps in the average case
+                prefetchNextLocsBi(tloc, bloc, tf[c], bf[c], tb[c], bb[c], i+1);
+
 		//
 		bool leaveZone = s.zones[i].first < 0;
 		//bool leaveZoneIns = zones_[i].second < 0;
 		Constraint& cons    = *zones[abs(s.zones[i].first)];
 		//Constraint& insCons = *zones[abs(s.zones[i].second)];
-		int c = (*seq_)[off];  assert_range(0, 4, c);
-		int q = (*qual_)[off];
+                int q = (*qual_)[off];
 		// Is it legal for us to advance on characters other than 'c'?
 		if(!(cons.mustMatch() && !overall.mustMatch()) || c == 4) {
 			// There may be legal edits

--- a/aligner_seed.h
+++ b/aligner_seed.h
@@ -1613,15 +1613,6 @@ protected:
 		Constraint overall,    // overall constraints
 		DoublyLinkedList<Edit> *prevEdit);  // previous edit
 	
-        inline void prefetchNextLocsBi(
-                SideLocus& tloc,            // top locus
-                SideLocus& bloc,            // bot locus
-                TIndexOffU topf,              // top in BWT
-                TIndexOffU botf,              // bot in BWT
-                TIndexOffU topb,              // top in BWT'
-                TIndexOffU botb,              // bot in BWT'
-                int step);                  // step to get ready for
-
 	/**
 	 * Get tloc and bloc ready for the next step.
 	 */
@@ -1634,6 +1625,13 @@ protected:
 		TIndexOffU botb,              // bot in BWT'
 		int step);                  // step to get ready for
 	
+	inline void prefetchNextLocsBi(
+		TIndexOffU topf,              // top in BWT
+		TIndexOffU botf,              // bot in BWT
+		TIndexOffU topb,              // top in BWT'
+		TIndexOffU botb,              // bot in BWT'
+		int step);                  // step to get ready for
+
 	// Following are set in searchAllSeeds then used by searchSeed()
 	// and other protected members.
 	const Ebwt* ebwtFw_;       // forward index (BWT)

--- a/aligner_seed.h
+++ b/aligner_seed.h
@@ -1613,6 +1613,15 @@ protected:
 		Constraint overall,    // overall constraints
 		DoublyLinkedList<Edit> *prevEdit);  // previous edit
 	
+        inline void prefetchNextLocsBi(
+                SideLocus& tloc,            // top locus
+                SideLocus& bloc,            // bot locus
+                TIndexOffU topf,              // top in BWT
+                TIndexOffU botf,              // bot in BWT
+                TIndexOffU topb,              // top in BWT'
+                TIndexOffU botb,              // bot in BWT'
+                int step);                  // step to get ready for
+
 	/**
 	 * Get tloc and bloc ready for the next step.
 	 */

--- a/bt2_idx.h
+++ b/bt2_idx.h
@@ -1852,6 +1852,7 @@ public:
 	 *
 	 * This is a performance-critical function.  This is the top search-
 	 * related hit in the time profile.
+	 * The bottleneck seems to be cache misses due to random memory access pattern.
 	 *
 	 * Function gets 11.09% in profile
 	 */
@@ -1952,6 +1953,10 @@ public:
 	 * Counts the number of occurrences of all four nucleotides in the
 	 * given side up to (but not including) the given byte/bitpair (by/bp).
 	 * Count for 'a' goes in arrs[0], 'c' in arrs[1], etc.
+	 *
+	 * This is a performance-critical function.  This is the top search-
+	 * related hit in the time profile.
+	 * The bottleneck seems to be cache misses due to random memory access pattern.
 	 */
 	inline void countUpToEx(const SideLocus& l, TIndexOffU* arrs) const {
 		int i = 0;

--- a/bt2_idx.h
+++ b/bt2_idx.h
@@ -346,26 +346,23 @@ struct SideLocus {
 			}
 		}
 
-        static void prefetchFromTopBot(
-                TIndexOffU top,
-                TIndexOffU bot,
-                const EbwtParams& ep,
-                const uint8_t* ebwt,
-                const SideLocus& ltop,
-                const SideLocus& lbot)
-                {
-                        const TIndexOffU sideBwtLen = ep._sideBwtLen;
-                        assert_gt(bot, top);
-                        ltop.prefetchFromRow(top, ep, ebwt);
-                        TIndexOffU spread = bot - top;
-                        // Many cache misses on the following lines
-                        if(ltop._charOff + spread < sideBwtLen) {
-   				// nothing to do
-                                //lbot._sideByteOff == ltop._sideByteOff;
-                        } else {
-                                lbot.prefetchFromRow(bot, ep, ebwt);
-                        }
-                }
+	static void prefetchFromTopBot(
+		TIndexOffU top,
+		TIndexOffU bot,
+		const EbwtParams& ep,
+		const uint8_t* ebwt,
+		const SideLocus& ltop,
+		const SideLocus& lbot)
+		{
+			const TIndexOffU sideBwtLen = ep._sideBwtLen;
+			assert_gt(bot, top);
+			ltop.prefetchFromRow(top, ep, ebwt);
+			TIndexOffU spread = bot - top;
+			if(!(ltop._charOff + spread < sideBwtLen)) {
+				lbot.prefetchFromRow(bot, ep, ebwt);
+			}
+			// else nothing too do, lbot._sideByteOff == ltop._sideByteOff
+		}
 
 	/**
 	 * Calculate SideLocus based on a row and other relevant
@@ -387,18 +384,17 @@ struct SideLocus {
 		_bp = _charOff & 3;  // bit-pair within byte
 	}
 
-        void prefetchFromRow(TIndexOffU row, const EbwtParams& ep, const uint8_t* ebwt) const {
-                const int32_t sideSz     = ep._sideSz;
-                // Side length is hard-coded for now; this allows the compiler
-                // to do clever things to accelerate / and %.
-                TIndexOffU sideNum                  = row / (48*OFF_SIZE);
-                TIndexOffU sideByteOff              = sideNum * sideSz;
-                TIndexOffU charOff                  = row % (48*OFF_SIZE);
-                TIndexOffU by = charOff >> 2; // byte within side
+	static void prefetchFromRow(TIndexOffU row, const EbwtParams& ep, const uint8_t* ebwt) {
+		const int32_t sideSz     = ep._sideSz;
+		// Side length is hard-coded for now; this allows the compiler
+		// to do clever things to accelerate / and %.
+		TIndexOffU sideNum                  = row / (48*OFF_SIZE);
+		TIndexOffU sideByteOff              = sideNum * sideSz;
 		__builtin_prefetch(ebwt + sideByteOff);
-                if (by>=64) __builtin_prefetch(ebwt + sideByteOff + 64); //64 byte cache lines
-		__builtin_prefetch(ebwt + sideByteOff + sideSz);
-        }
+#if (OFF_SIZE>4)
+		__builtin_prefetch(ebwt + sideByteOff + 64); //64 byte cache lines
+#endif
+	}
 
 	/**
 	 * Transform this SideLocus to refer to the next side (i.e. the one


### PR DESCRIPTION
Profiling shows that we spend a lot of time waiting on access to content of side().
Since access is not sequential, the CPU needs hints ASAP on which cache line will be hit next.
Adding explicit prefetch commands achieves that goal.