### PR TITLE
Improve prefetch effectiveness by refactoring loops in SeedAligner::searchAllSeeds, SeedAligner::searchSeedBi and SeedAligner::exactSweep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ HEADERS := $(wildcard *.h)
 BOWTIE_MM := 1
 BOWTIE_SHARED_MEM :=
 
-CXXFLAGS += -std=c++17
+CXXFLAGS += -std=c++11
 
 ARCH = $(shell uname -m)
 NGS_VER ?= 2.9.2

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ HEADERS := $(wildcard *.h)
 BOWTIE_MM := 1
 BOWTIE_SHARED_MEM :=
 
-CXXFLAGS += -std=c++11
+CXXFLAGS += -std=c++17
 
 ARCH = $(shell uname -m)
 NGS_VER ?= 2.9.2

--- a/aligner_cache.h
+++ b/aligner_cache.h
@@ -883,7 +883,7 @@ public:
 	 * compiled for the current read in the local cache.
 	 */
 	bool addOnTheFly(
-		const BTDnaString& rfseq, // reference sequence close to read seq
+		const SAKey& sak, // the key holding the reference substring
 		TIndexOffU topf,            // top in BWT index
 		TIndexOffU botf,            // bot in BWT index
 		TIndexOffU topb,            // top in BWT' index
@@ -893,8 +893,6 @@ public:
 
 		assert(aligning());
 		assert(repOk());
-		ASSERT_ONLY(BTDnaString tmp);
-		SAKey sak(rfseq ASSERT_ONLY(, tmp));
 		//assert(sak.cacheable());
 		if(current_->addOnTheFly((*qv_), sak, topf, botf, topb, botb, getLock)) {
 			rangen_++;
@@ -902,6 +900,20 @@ public:
 			return true;
 		}
 		return false;
+	}
+
+	bool addOnTheFly(
+		const BTDnaString& rfseq, // reference sequence close to read seq
+		TIndexOffU topf,            // top in BWT index
+		TIndexOffU botf,            // bot in BWT index
+		TIndexOffU topb,            // top in BWT' index
+		TIndexOffU botb,            // bot in BWT' index
+		bool getLock = true)      // true -> lock is not held by caller
+	{
+
+		ASSERT_ONLY(BTDnaString tmp);
+		SAKey sak(rfseq ASSERT_ONLY(, tmp));
+		return addOnTheFly(sak, topf, botf, topb, botb, getLock);
 	}
 
 	/**

--- a/aligner_cache.h
+++ b/aligner_cache.h
@@ -771,8 +771,6 @@ public:
 	 * Returns:
 	 *  -1 if out of memory
 	 *  0 if key was found in cache
-	 *  1 if key was not found in cache (and there's enough memory to
-	 *    add a new key)
 	 */
 	int beginAlign(
 		const BTDnaString& seq,
@@ -782,13 +780,6 @@ public:
 	{
 		assert(repOk());
 		qk_.init(seq ASSERT_ONLY(, tmpdnastr_));
-		//if(qk_.cacheable() && (qv_ = current_->query(qk_, getLock)) != NULL) {
-		//	// qv_ holds the answer
-		//	assert(qv_->valid());
-		//	qv = *qv_;
-		//	resetRead();
-		//	return 1; // found in cache
-		//} else
 		if(qk_.cacheable()) {
 			// Make a QNode for this key and possibly add the QNode to the
 			// Red-Black map; but if 'seq' isn't cacheable, just create the

--- a/aligner_cache.h
+++ b/aligner_cache.h
@@ -684,6 +684,24 @@ public:
 		assert(current_ != NULL);
 	}
 
+	/**
+         * The new object will share the cache pointers
+	 */
+	AlignmentCacheIface(AlignmentCacheIface& other) :
+		qk_(),
+		qv_(NULL),
+		cacheable_(false),
+		rangen_(0),
+		eltsn_(0),
+		current_(other.current_),
+		local_(other.local_),
+		shared_(other.shared_)
+	{
+		assert(current_ != NULL);
+	}
+
+	AlignmentCacheIface(AlignmentCacheIface&& other)  = default;
+
 #if 0
 	/**
 	 * Query the relevant set of caches, looking for a QVal to go with

--- a/aligner_cache.h
+++ b/aligner_cache.h
@@ -65,6 +65,39 @@
 
 #define CACHE_PAGE_SZ (16 * 1024)
 
+class BwtTopBot {
+public:
+	BwtTopBot() : topf(0), botf(0), topb(0), botb(0) {}
+
+	BwtTopBot(
+		TIndexOffU _topf,        // top in BWT
+		TIndexOffU _botf,        // bot in BWT
+		TIndexOffU _topb,        // top in BWT'
+		TIndexOffU _botb)        // bot in BWT'
+	: topf(_topf)
+	, botf(_botf)
+	, topb(_topb)
+	, botb(_botb)
+	{}
+
+	void set(
+		TIndexOffU _topf,        // top in BWT
+		TIndexOffU _botf,        // bot in BWT
+		TIndexOffU _topb,        // top in BWT'
+		TIndexOffU _botb)        // bot in BWT'
+	{
+		topf = _topf;
+		botf = _botf;
+		topb = _topb;
+		botb = _botb;
+	}
+
+	TIndexOffU topf;        // top in BWT
+	TIndexOffU botf;        // bot in BWT
+	TIndexOffU topb;        // top in BWT'
+	TIndexOffU botb;        // bot in BWT'
+};
+
 typedef PListSlice<TIndexOffU, CACHE_PAGE_SZ> TSlice;
 
 /**

--- a/aligner_cache.h
+++ b/aligner_cache.h
@@ -684,24 +684,6 @@ public:
 		assert(current_ != NULL);
 	}
 
-	/**
-         * The new object will share the cache pointers
-	 */
-	AlignmentCacheIface(AlignmentCacheIface& other) :
-		qk_(),
-		qv_(NULL),
-		cacheable_(false),
-		rangen_(0),
-		eltsn_(0),
-		current_(other.current_),
-		local_(other.local_),
-		shared_(other.shared_)
-	{
-		assert(current_ != NULL);
-	}
-
-	AlignmentCacheIface(AlignmentCacheIface&& other)  = default;
-
 #if 0
 	/**
 	 * Query the relevant set of caches, looking for a QVal to go with

--- a/aligner_seed.cpp
+++ b/aligner_seed.cpp
@@ -845,21 +845,24 @@ size_t SeedAligner::exactSweep(
 		size_t dep = 0;
 		size_t nedit = 0;
 		bool done = false;
+		bool doInit = true;
 		while(dep < len && !done) {
-			exactSweepInit(ebwt, seq, ftabLen, len,  // in
-					dep, top, bot);          // out
-			if ( exactSweepStep(ebwt, top, bot, mineMax,
-					tloc, bloc,
-					fw ? mineFw : mineRc,
-					nedit, done) ) {
-				continue;
+			if (doInit) {
+				exactSweepInit(ebwt, seq, ftabLen, len,  // in
+						dep, top, bot);          // out
+				if ( exactSweepStep(ebwt, top, bot, mineMax,
+						tloc, bloc,
+						fw ? mineFw : mineRc,
+						nedit, done) ) {
+					continue;
+				}
+				doInit=false;
 			}
-			// Keep going
-			while(dep < len) {
-				int c = seq[len-dep-1];
-				if(c > 3) {
+
+			int c = seq[len-dep-1];
+			if(c > 3) {
 					top = bot = 0;
-				} else {
+			} else {
 					if(bloc.valid()) {
 						bwops_ += 2;
 						top = ebwt.mapLF(tloc, c);
@@ -873,14 +876,12 @@ size_t SeedAligner::exactSweep(
 							bot = top+1;
 						}
 					}
-				}
-				if ( exactSweepStep(ebwt, top, bot, mineMax,
+			}
+			if ( exactSweepStep(ebwt, top, bot, mineMax,
 						tloc, bloc,
 						fw ? mineFw : mineRc,
 						nedit, done) ) {
-					break;
-				}
-				dep++;
+				doInit=true;
 			}
 			dep++;
 		}

--- a/aligner_seed.cpp
+++ b/aligner_seed.cpp
@@ -925,16 +925,18 @@ size_t SeedAligner::exactSweep(
 					doInit[fwi]=false;
 				}
 
-				exactSweepMapLF(ebwt, seq, len, dep[fwi], tloc[fwi], bloc[fwi],
-						top[fwi], bot[fwi], bwops_);
+				if (dep[fwi]< len) {
+					exactSweepMapLF(ebwt, seq, len, dep[fwi], tloc[fwi], bloc[fwi],
+							top[fwi], bot[fwi], bwops_);
 
-				if ( exactSweepStep(ebwt, top[fwi], bot[fwi], mineMax,
-							tloc[fwi], bloc[fwi],
-							fw ? mineFw : mineRc,
-							nedit[fwi], done[fwi]) ) {
-					doInit[fwi]=true;
+					if ( exactSweepStep(ebwt, top[fwi], bot[fwi], mineMax,
+								tloc[fwi], bloc[fwi],
+								fw ? mineFw : mineRc,
+								nedit[fwi], done[fwi]) ) {
+						doInit[fwi]=true;
+					}
+					dep[fwi]++;
 				}
-				dep[fwi]++;
 			}
 		}
 	}

--- a/aligner_seed.cpp
+++ b/aligner_seed.cpp
@@ -17,6 +17,7 @@
  * along with Bowtie 2.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <array>
 #include "aligner_cache.h"
 #include "aligner_seed.h"
 #include "search_globals.h"

--- a/aligner_seed.cpp
+++ b/aligner_seed.cpp
@@ -1106,19 +1106,81 @@ bool SeedAligner::oneMmSearch(
 	return results;
 }
 
+class SeedAlignerSearchParams {
+public:
+	BwtTopBot bwt;         // The 4 BWT idxs
+	SideLocus tloc;       // locus for top (perhaps unititialized)
+	SideLocus bloc;       // locus for bot (perhaps unititialized)
+	std::array<Constraint,3> cv;        // constraints to enforce in seed zones
+	Constraint overall;   // overall constraints to enforce
+	DoublyLinkedList<Edit> *prevEdit;  // previous edit
+
+	SeedAlignerSearchParams(
+		const BwtTopBot &_bwt,         // The 4 BWT idxs
+		const SideLocus &_tloc,       // locus for top (perhaps unititialized)
+		const SideLocus &_bloc,       // locus for bot (perhaps unititialized)
+		const std::array<Constraint,3> _cv,        // constraints to enforce in seed zones
+		const Constraint &_overall,   // overall constraints to enforce
+		DoublyLinkedList<Edit> *_prevEdit)  // previous edit
+	: bwt(_bwt)
+	, tloc(_tloc)
+	, bloc(_bloc)
+	, cv(_cv)
+	, overall(_overall)
+	, prevEdit(_prevEdit)
+	{}
+
+	SeedAlignerSearchParams(
+		const BwtTopBot &_bwt,         // The 4 BWT idxs
+		const SideLocus &_tloc,       // locus for top (perhaps unititialized)
+		const SideLocus &_bloc,       // locus for bot (perhaps unititialized)
+		const Constraint &_c0,        // constraints to enforce in seed zone 0
+		const Constraint &_c1,        // constraints to enforce in seed zone 1
+		const Constraint &_c2,        // constraints to enforce in seed zone 2
+		const Constraint &_overall,   // overall constraints to enforce
+		DoublyLinkedList<Edit> *_prevEdit)  // previous edit
+	: bwt(_bwt)
+	, tloc(_tloc)
+	, bloc(_bloc)
+	, cv{ _c0, _c1, _c2 }
+	, overall(_overall)
+	, prevEdit(_prevEdit)
+	{}
+
+	// create an empty bwt, tloc and bloc
+	SeedAlignerSearchParams(
+		const Constraint &_c0,        // constraints to enforce in seed zone 0
+		const Constraint &_c1,        // constraints to enforce in seed zone 1
+		const Constraint &_c2,        // constraints to enforce in seed zone 2
+		const Constraint &_overall,   // overall constraints to enforce
+		DoublyLinkedList<Edit> *_prevEdit)  // previous edit
+	: bwt()
+	, tloc()
+	, bloc()
+	, cv{ _c0, _c1, _c2 }
+	, overall(_overall)
+	, prevEdit(_prevEdit)
+	{}
+
+	void checkCV() const {
+			assert(cv[0].acceptable());
+			assert(cv[1].acceptable());
+			assert(cv[2].acceptable());
+	}
+
+};
+
 /**
  * Wrapper for initial invocation of searchSeed.
  */
 void
 SeedAligner::searchSeedBi(SeedSearchInput &params) {
 	const InstantiatedSeed& seed = params.seed;
+	SeedAlignerSearchParams p(seed.cons[0], seed.cons[1], seed.cons[2], seed.overall, NULL);
 	searchSeedBi(
 		params,
 		0, 0,
-		BwtTopBot(),
-		SideLocus(), SideLocus(),
-		seed.cons[0], seed.cons[1], seed.cons[2], seed.overall,
-		NULL);
+		p);
 }
 
 inline void
@@ -1433,14 +1495,8 @@ bool
 SeedAligner::startSearchSeedBi(
 	SeedSearchInput &params,
 	int depth,            // recursion depth
-	const Constraint &c0, // constraints to enforce in seed zone 0
-	const Constraint &c1, // constraints to enforce in seed zone 1
-	const Constraint &c2, // constraints to enforce in seed zone 2
-	DoublyLinkedList<Edit> *prevEdit,  // previous edit
 	int &step,            // depth into steps_[] array
-	BwtTopBot &bwt,       // The 4 BWT idxs
-	SideLocus &tloc,      // locus for top (perhaps unititialized)
-	SideLocus &bloc       // locus for bot (perhaps unititialized)
+	SeedAlignerSearchParams &p
 	)
 {
 	SeedSearchCache &cache = params.cache;
@@ -1456,23 +1512,21 @@ SeedAligner::startSearchSeedBi(
 #endif
 	if(step == (int)seed.steps.size()) {
 		// Finished aligning seed
-		assert(c0.acceptable());
-		assert(c1.acceptable());
-		assert(c2.acceptable());
-		reportHit(cache, bwt, seq.length(), prevEdit);
+		p.checkCV();
+		reportHit(cache, p.bwt, seq.length(), p.prevEdit);
 		return true;
 	}
 #ifndef NDEBUG
 	if(depth > 0) {
-		assert(bwt.botf - bwt.topf == 1 ||  bloc.valid());
-		assert(bwt.botf - bwt.topf > 1  || !bloc.valid());
+		assert(p.bwt.botf - p.bwt.topf == 1 ||  p.bloc.valid());
+		assert(p.bwt.botf - p.bwt.topf > 1  || !p.bloc.valid());
 	}
 #endif
 	if(step == 0) {
 		// Just starting
-		assert(prevEdit == NULL);
-		assert(!tloc.valid());
-		assert(!bloc.valid());
+		assert(p.prevEdit == NULL);
+		assert(!p.tloc.valid());
+		assert(!p.bloc.valid());
 		int off = seed.steps[0];
 		bool ltr = off > 0;
 		off = abs(off)-1;
@@ -1483,50 +1537,48 @@ SeedAligner::startSearchSeedBi(
 				assert_geq(off+1, ftabLen-1);
 				off = off - ftabLen + 1;
 			}
-			ebwtFw_->ftabLoHi(seq, off, false, bwt.topf, bwt.botf);
+			ebwtFw_->ftabLoHi(seq, off, false, p.bwt.topf, p.bwt.botf);
 			#ifdef NDEBUG
-			if(bwt.botf - bwt.topf == 0) return true;
+			if(p.bwt.botf - p.bwt.topf == 0) return true;
 			#endif
 			#ifdef NDEBUG
 			if(ebwtBw_ != NULL) {
-				bwt.topb = ebwtBw_->ftabHi(seq, off);
-				bwt.botb = bwt.topb + (bwt.botf-bwt.topf);
+				p.bwt.topb = ebwtBw_->ftabHi(seq, off);
+				p.bwt.botb = p.bwt.topb + (p.bwt.botf-p.bwt.topf);
 			}
 			#else
 			if(ebwtBw_ != NULL) {
-				ebwtBw_->ftabLoHi(seq, off, false, bwt.topb, bwt.botb);
-				assert_eq(bwt.botf-bwt.topf, bwt.botb-bwt.topb);
+				ebwtBw_->ftabLoHi(seq, off, false, p.bwt.topb, p.bwt.botb);
+				assert_eq(p.bwt.botf-p.bwt.topf, p.bwt.botb-p.bwt.topb);
 			}
-			if(bwt.botf - bwt.topf == 0) return true;
+			if(p.bwt.botf - p.bwt.topf == 0) return true;
 			#endif
 			step += ftabLen;
 		} else if(seed.maxjump > 0) {
 			// Use fchr
 			int c = seq[off];
 			assert_range(0, 3, c);
-			bwt.topf = bwt.topb = ebwtFw_->fchr()[c];
-			bwt.botf = bwt.botb = ebwtFw_->fchr()[c+1];
-			if(bwt.botf - bwt.topf == 0) return true;
+			p.bwt.topf = p.bwt.topb = ebwtFw_->fchr()[c];
+			p.bwt.botf = p.bwt.botb = ebwtFw_->fchr()[c+1];
+			if(p.bwt.botf - p.bwt.topf == 0) return true;
 			step++;
 		} else {
 			assert_eq(0, seed.maxjump);
-			bwt.topf = bwt.topb = 0;
-			bwt.botf = bwt.botb = ebwtFw_->fchr()[4];
+			p.bwt.topf = p.bwt.topb = 0;
+			p.bwt.botf = p.bwt.botb = ebwtFw_->fchr()[4];
 		}
 		if(step == (int)seed.steps.size()) {
 			// Finished aligning seed
-			assert(c0.acceptable());
-			assert(c1.acceptable());
-			assert(c2.acceptable());
-			reportHit(cache, bwt, seq.length(), prevEdit);
+			p.checkCV();
+			reportHit(cache, p.bwt, seq.length(), p.prevEdit);
 			return true;
 		}
-		nextLocsBi(seed, tloc, bloc, bwt, step);
-		assert(tloc.valid());
-	} else assert(prevEdit != NULL);
-	assert(tloc.valid());
-	assert(bwt.botf - bwt.topf == 1 ||  bloc.valid());
-	assert(bwt.botf - bwt.topf > 1  || !bloc.valid());
+		nextLocsBi(seed, p.tloc, p.bloc, p.bwt, step);
+		assert(p.tloc.valid());
+	} else assert(p.prevEdit != NULL);
+	assert(p.tloc.valid());
+	assert(p.bwt.botf - p.bwt.topf == 1 ||  p.bloc.valid());
+	assert(p.bwt.botf - p.bwt.topf > 1  || !p.bloc.valid());
 	assert_geq(step, 0);
 
 	return false;
@@ -1600,14 +1652,7 @@ SeedAligner::searchSeedBi(
 	SeedSearchInput &params,
 	int step,             // depth into steps_[] array
 	int depth,            // recursion depth
-	BwtTopBot bwt,         // The 4 BWT idxs
-	SideLocus tloc,       // locus for top (perhaps unititialized)
-	SideLocus bloc,       // locus for bot (perhaps unititialized)
-	Constraint c0,        // constraints to enforce in seed zone 0
-	Constraint c1,        // constraints to enforce in seed zone 1
-	Constraint c2,        // constraints to enforce in seed zone 2
-	Constraint overall,   // overall constraints to enforce
-	DoublyLinkedList<Edit> *prevEdit  // previous edit
+	SeedAlignerSearchParams &p // all the remaining params
 #if 0
 	, const SABWOffTrack* prevOt // prev off tracker (if tracking started)
 #endif
@@ -1620,31 +1665,29 @@ SeedAligner::searchSeedBi(
 
 	bool done = startSearchSeedBi(
 			params,
-			depth, c0, c1, c2, prevEdit,
+			depth,
 			step,
-			bwt,
-			tloc, bloc);
+			p);
 	if(done) {
 		return;
 	}
 
 	SeedAlignerSearchState sstate;
-	sstate.initLastTot(bwt.botf - bwt.topf);
-	Constraint* zones[3] = { &c0, &c1, &c2 };
+	sstate.initLastTot(p.bwt.botf - p.bwt.topf);
 	for(size_t i = step; i < seed.steps.size(); i++) {
-		assert_gt(bwt.botf, bwt.topf);
-		assert(bwt.botf - bwt.topf == 1 ||  bloc.valid());
-		assert(bwt.botf - bwt.topf > 1  || !bloc.valid());
-		assert(ebwtBw_ == NULL || bwt.botf-bwt.topf == bwt.botb-bwt.topb);
-		assert(tloc.valid());
-		sstate.setOff(seed.steps[i], bwt, ebwtFw_, ebwtBw_);
+		assert_gt(p.bwt.botf, p.bwt.topf);
+		assert(p.bwt.botf - p.bwt.topf == 1 ||  p.bloc.valid());
+		assert(p.bwt.botf - p.bwt.topf > 1  || !p.bloc.valid());
+		assert(ebwtBw_ == NULL || p.bwt.botf-p.bwt.topf == p.bwt.botb-p.bwt.topb);
+		assert(p.tloc.valid());
+		sstate.setOff(seed.steps[i], p.bwt, ebwtFw_, ebwtBw_);
 		__builtin_prefetch(&(seq[sstate.off]));
 		__builtin_prefetch(&(qual[sstate.off]));
-		if(bloc.valid()) {
+		if(p.bloc.valid()) {
 			// Range delimited by tloc/bloc has size >1.  If size == 1,
 			// we use a simpler query (see if(!bloc.valid()) blocks below)
 			bwops_++;
-			sstate.ebwt->mapBiLFEx(tloc, bloc, sstate.t, sstate.b, sstate.tp, sstate.bp);
+			sstate.ebwt->mapBiLFEx(p.tloc, p.bloc, sstate.t, sstate.b, sstate.tp, sstate.bp);
 			ASSERT_ONLY(TIndexOffU tot = (sstate.b[0]-sstate.t[0])+(sstate.b[1]-sstate.t[1])+(sstate.b[2]-sstate.t[2])+(sstate.b[3]-sstate.t[3]));
 			ASSERT_ONLY(TIndexOffU totp = (sstate.bp[0]-sstate.tp[0])+(sstate.bp[1]-sstate.tp[1])+(sstate.bp[2]-sstate.tp[2])+(sstate.bp[3]-sstate.tp[3]));
 			assert_eq(tot, totp);
@@ -1660,72 +1703,72 @@ SeedAligner::searchSeedBi(
 		//
 		bool leaveZone = seed.zones[i].first < 0;
 		//bool leaveZoneIns = zones_[i].second < 0;
-		Constraint& cons    = *zones[abs(seed.zones[i].first)];
-		//Constraint& insCons = *zones[abs(seed.zones[i].second)];
+		Constraint& cons    = p.cv[abs(seed.zones[i].first)];
+		//Constraint& insCons = p.cv[abs(seed.zones[i].second)];
 		// Is it legal for us to advance on characters other than 'c'?
-		if(!(cons.mustMatch() && !overall.mustMatch()) || c == 4) {
+		if(!(cons.mustMatch() && !p.overall.mustMatch()) || c == 4) {
 			// There may be legal edits
 			bool bail = false;
-			if(!bloc.valid()) {
+			if(!p.bloc.valid()) {
 				// Range delimited by tloc/bloc has size 1
 				bwops_++;
-				int cc = sstate.ebwt->mapLF1(sstate.ntop, tloc);
+				int cc = sstate.ebwt->mapLF1(sstate.ntop, p.tloc);
 				assert_range(-1, 3, cc);
 				if(cc < 0) bail = true;
 				else { sstate.t[cc] = sstate.ntop; sstate.b[cc] = sstate.ntop+1; }
 			}
 			if(!bail) {
 				int q = qual[sstate.off];
-				if((cons.canMismatch(q, *sc_) && overall.canMismatch(q, *sc_)) || c == 4) {
-					Constraint oldCons = cons, oldOvCons = overall;
-					SideLocus oldTloc = tloc, oldBloc = bloc;
+				if((cons.canMismatch(q, *sc_) && p.overall.canMismatch(q, *sc_)) || c == 4) {
+					Constraint oldCons = cons, oldOvCons = p.overall;
+					SideLocus oldTloc = p.tloc, oldBloc = p.bloc;
 					if(c != 4) {
 						cons.chargeMismatch(q, *sc_);
-						overall.chargeMismatch(q, *sc_);
+						p.overall.chargeMismatch(q, *sc_);
 					}
 					// Can leave the zone as-is
-					if(!leaveZone || (cons.acceptable() && overall.acceptable())) {
+					if(!leaveZone || (cons.acceptable() && p.overall.acceptable())) {
 						for(int j = 0; j < 4; j++) {
 							if(j == c || sstate.b[j] == sstate.t[j]) continue;
 							BwtTopBot bwt2(sstate.tf[j], sstate.bf[j], sstate.tb[j], sstate.bb[j]);
 							// Potential mismatch
-							nextLocsBi(seed, tloc, bloc, bwt2, i+1);
+							nextLocsBi(seed, p.tloc, p.bloc, bwt2, i+1);
 							int loff = sstate.off;
 							if(!sstate.ltr) loff = (int)(seed.steps.size() - loff - 1);
-							assert(prevEdit == NULL || prevEdit->next == NULL);
+							assert(p.prevEdit == NULL || p.prevEdit->next == NULL);
 							Edit edit(sstate.off, j, c, EDIT_TYPE_MM, false);
 							DoublyLinkedList<Edit> editl;
 							editl.payload = edit;
-							if(prevEdit != NULL) {
-								prevEdit->next = &editl;
-								editl.prev = prevEdit;
+							if(p.prevEdit != NULL) {
+								p.prevEdit->next = &editl;
+								editl.prev = p.prevEdit;
 							}
 							assert(editl.next == NULL);
 							bwedits_++;
+							SeedAlignerSearchParams p2(
+								bwt2,    // The 4 BWT idxs
+								p.tloc,  // locus for top (perhaps unititialized)
+								p.bloc,  // locus for bot (perhaps unititialized)
+								p.cv,    // constraints to enforce in seed zones
+								p.overall, // overall constraints to enforce
+								&editl);  // latest edit
 							searchSeedBi(
 								params,
 								i+1,     // depth into steps_[] array
 								depth+1, // recursion depth
-								bwt2,    // The 4 BWT idxs
-								tloc,    // locus for top (perhaps unititialized)
-								bloc,    // locus for bot (perhaps unititialized)
-								c0,      // constraints to enforce in seed zone 0
-								c1,      // constraints to enforce in seed zone 1
-								c2,      // constraints to enforce in seed zone 2
-								overall, // overall constraints to enforce
-								&editl);  // latest edit
-							if(prevEdit != NULL) prevEdit->next = NULL;
+								p2);
+							if(p.prevEdit != NULL) p.prevEdit->next = NULL;
 						}
 					} else {
 						// Not enough edits to make this path
 						// non-redundant with other seeds
 					}
 					cons = oldCons;
-					overall = oldOvCons;
-					tloc = oldTloc;
-					bloc = oldBloc;
+					p.overall = oldOvCons;
+					p.tloc = oldTloc;
+					p.bloc = oldBloc;
 				}
-				if(cons.canGap() && overall.canGap()) {
+				if(cons.canGap() && p.overall.canGap()) {
 					throw 1; // TODO
 //					int delEx = 0;
 //					if(cons.canDelete(delEx, *sc_) && overall.canDelete(delEx, *sc_)) {
@@ -1741,16 +1784,16 @@ SeedAligner::searchSeedBi(
 		if(c == 4) {
 			return; // couldn't handle the N
 		}
-		if(leaveZone && (!cons.acceptable() || !overall.acceptable())) {
+		if(leaveZone && (!cons.acceptable() || !p.overall.acceptable())) {
 			// Not enough edits to make this path non-redundant with
 			// other seeds
 			return;
 		}
-		if(!bloc.valid()) {
+		if(!p.bloc.valid()) {
 			assert(ebwtBw_ == NULL || sstate.bp[c] == sstate.tp[c]+1);
 			// Range delimited by tloc/bloc has size 1
 			bwops_++;
-			sstate.t[c] = sstate.ebwt->mapLF1(sstate.ntop, tloc, c);
+			sstate.t[c] = sstate.ebwt->mapLF1(sstate.ntop, p.tloc, c);
 			if(sstate.t[c] == OFF_MASK) {
 				return;
 			}
@@ -1764,16 +1807,14 @@ SeedAligner::searchSeedBi(
 		if(sstate.b[c] == sstate.t[c]) {
 			return;
 		}
-		bwt.set(sstate.tf[c], sstate.bf[c], sstate.tb[c], sstate.bb[c]);
+		p.bwt.set(sstate.tf[c], sstate.bf[c], sstate.tb[c], sstate.bb[c]);
 		if(i+1 == seed.steps.size()) {
 			// Finished aligning seed
-			assert(c0.acceptable());
-			assert(c1.acceptable());
-			assert(c2.acceptable());
-			reportHit(cache, bwt, seq.length(), prevEdit);
+			p.checkCV();
+			reportHit(cache, p.bwt, seq.length(), p.prevEdit);
 			return;
 		}
-		nextLocsBi(seed, tloc, bloc, bwt, i+1);
+		nextLocsBi(seed, p.tloc, p.bloc, p.bwt, i+1);
 	}
 	return;
 }

--- a/aligner_seed.cpp
+++ b/aligner_seed.cpp
@@ -532,7 +532,7 @@ void SeedAligner::searchAllSeeds(
 				continue;
 			}
 			bool abort = false;
-			if(ret == 0) {
+			{
 				// Not already in cache
 				assert(srcache.aligning());
 				possearches++;
@@ -557,11 +557,6 @@ void SeedAligner::searchAllSeeds(
 				if(!abort) {
 					srcache.finishAlign();
 				}
-			} else {
-				// Already in cache
-				assert_eq(1, ret);
-				assert(srcache.qvValid());
-				intrahits++;
 			}
 			assert(abort || !srcache.aligning());
 			if(srcache.qvValid()) {

--- a/aligner_seed.cpp
+++ b/aligner_seed.cpp
@@ -489,6 +489,12 @@ void SeedAligner::searchAllSeeds(
 	read_ = &read;
 	bwops_ = bwedits_ = 0;
 	uint64_t possearches = 0, seedsearches = 0, intrahits = 0, interhits = 0, ooms = 0;
+
+	// Use MultiCache to validate functionality
+	// TODO: decouple creation and use
+	SeedSearchMultiCache mcache(cache);
+	mcache.reserve(sr.numOffs()*2);
+
 	// For each instantiated seed
 	for(int i = 0; i < (int)sr.numOffs(); i++) {
 		for(int fwi = 0; fwi < 2; fwi++) {
@@ -501,7 +507,8 @@ void SeedAligner::searchAllSeeds(
 			}
 			const BTDnaString& seq  = sr.seqs(fw)[i];  // seed sequence
 			const BTString& qual = sr.quals(fw)[i]; // seed qualities
-			SeedSearchCache srcache(cache, seq, qual);
+			mcache.emplace_back(seq,qual);
+			SeedSearchCache &srcache = mcache[mcache.size()-1];
 			// Tell the cache that we've started aligning, so the cache can
 			// expect a series of on-the-fly updates
 			int ret = srcache.beginAlign();

--- a/aligner_seed.cpp
+++ b/aligner_seed.cpp
@@ -882,10 +882,9 @@ size_t SeedAligner::exactSweep(
 				}
 				dep++;
 			}
-			if(done) {
-				break;
-			}
-			if(dep == len) {
+			dep++;
+		}
+		if( (!done) && (dep >= len) ) {
 				// Set the minimum # edits
 				if(fw) { mineFw = nedit; } else { mineRc = nedit; }
 				// Done
@@ -903,9 +902,6 @@ size_t SeedAligner::exactSweep(
 					}
 					nelt += (bot - top);
 				}
-				break;
-			}
-			dep++;
 		}
 	}
 	return nelt;

--- a/aligner_seed.cpp
+++ b/aligner_seed.cpp
@@ -510,8 +510,9 @@ void SeedAligner::searchAllSeeds(
 			}
 			const BTDnaString& seq  = sr.seqs(fw)[i];  // seed sequence
 			const BTString& qual = sr.quals(fw)[i]; // seed qualities
-			mcache.emplace_back(seq,qual);
-			SeedSearchCache &srcache = mcache[mcache.size()-1];
+			mcache.emplace_back(seq, qual, i, fw);
+			const size_t mnr = mcache.size()-1;
+			SeedSearchCache &srcache = mcache[mnr];
 			// Tell the cache that we've started aligning, so the cache can
 			// expect a series of on-the-fly updates
 			int ret = srcache.beginAlign();
@@ -558,8 +559,8 @@ void SeedAligner::searchAllSeeds(
 				sr.add(
 					srcache.getQv(),   // range of ranges in cache
 					srcache.current(), // cache
-					i,     // seed index (from 5' end)
-					fw);   // whether seed is from forward read
+					mcache.getSeedOffIdx(mnr),     // seed index (from 5' end)
+					mcache.getFw(mnr));   // whether seed is from forward read
 			}
 		}
 	}

--- a/aligner_seed.cpp
+++ b/aligner_seed.cpp
@@ -550,6 +550,12 @@ void SeedAligner::searchAllSeeds(
 						abort = true;
 						break;
 					}
+					if(!srcache.addAllCached()){
+						// Memory exhausted during copy
+						ooms++;
+						abort = true;
+						break;
+					}
 					seedsearches++;
 					assert(srcache.aligning());
 				}
@@ -1401,16 +1407,15 @@ SeedAligner::reportHit(
 	} else {
 		rf = seq;
 	}
+	// Note: Disabled, as we now use memory cache
 	// Sanity check: shouldn't add the same hit twice.  If this
 	// happens, it may be because our zone Constraints are not set up
 	// properly and erroneously return true from acceptable() when they
 	// should return false in some cases.
-	assert_eq(hits_.size(), cache.curNumRanges());
-	assert(hits_.insert(rf));
-	if(!cache.addOnTheFly(rf, topf, botf, topb, botb)) {
-		return false;
-	}
-	assert_eq(hits_.size(), cache.curNumRanges());
+	//assert_eq(hits_.size(), cache.curNumRanges());
+	//assert(hits_.insert(rf));
+	cache.addOnTheFly(rf, topf, botf, topb, botb);
+	//assert_eq(hits_.size(), cache.curNumRanges());
 #ifndef NDEBUG
 	// Sanity check that the topf/botf and topb/botb ranges really
 	// correspond to the reference sequence aligned to

--- a/aligner_seed.cpp
+++ b/aligner_seed.cpp
@@ -493,7 +493,7 @@ void SeedAligner::searchAllSeeds(
 	// TODO: Define is somewhere else
 	const int ibatch_size = 8;
 
-	SeedSearchMultiCache mcache(cache);
+	SeedSearchMultiCache mcache;
 	std::vector<SeedSearchInput> paramVec;
 
 	mcache.reserve(ibatch_size);
@@ -545,7 +545,7 @@ void SeedAligner::searchAllSeeds(
 			SeedSearchCache &srcache = mcache[mnr];
 			// Tell the cache that we've started aligning, so the cache can
 			// expect a series of on-the-fly updates
-			int ret = srcache.beginAlign();
+			int ret = srcache.beginAlign(cache);
 			if(ret == -1) {
 				// Out of memory when we tried to add key to map
 				ooms++;
@@ -562,7 +562,7 @@ void SeedAligner::searchAllSeeds(
 			if(srcache.qvValid()) {
 				sr.add(
 					srcache.getQv(),   // range of ranges in cache
-					srcache.current(), // cache
+					cache.current(), // cache
 					mcache.getSeedOffIdx(mnr),     // seed index (from 5' end)
 					mcache.getFw(mnr));   // whether seed is from forward read
 			}

--- a/aligner_seed.cpp
+++ b/aligner_seed.cpp
@@ -615,7 +615,12 @@ void SeedAligner::searchAllSeeds(
 	bwops_ = bwedits_ = 0;
 	uint64_t possearches = 0, seedsearches = 0, intrahits = 0, interhits = 0, ooms = 0;
 
-	// TODO: Define is somewhere else
+	/**
+	 * TODO: Define is somewhere else
+	 * Note: The ideal may be dependent on the CPU model, but 8 seems to work fine.
+	 *       2 is too small for prefetch to be fully effective, 4 seems already OK, 
+	 *       and 32 is too big (cache trashing).
+	 **/
 	const int ibatch_size = 8;
 
 	SeedSearchMultiCache mcache;

--- a/aligner_seed.cpp
+++ b/aligner_seed.cpp
@@ -534,11 +534,7 @@ void SeedAligner::searchAllSeeds(
 		   } // internal i (batch) loop
 
 		   // do the searches
-		   for (size_t pnr=0; pnr<paramVec.size(); pnr++) {
-			SeedSearchInput &srinput = paramVec[pnr];
-			// Do the search with respect to srinput
-			searchSeedBi(srinput);
-		   } // pnr loop
+		   if (!paramVec.empty()) searchSeedBi(paramVec.size(), &(paramVec[0]));
 
 		   // finish aligning and add to SeedResult
 		   for (size_t mnr=0; mnr<mcache.size(); mnr++) {
@@ -1187,12 +1183,13 @@ public:
  * Wrapper for initial invocation of searchSeed.
  */
 void
-SeedAligner::searchSeedBi(SeedSearchInput &params) {
-	const InstantiatedSeed& seed = params.seed;
-	SeedAlignerSearchParams p(params, seed.cons[0], seed.cons[1], seed.cons[2], seed.overall, NULL);
-	searchSeedBi(
-		p,
-		0); 
+SeedAligner::searchSeedBi(const size_t nparams, SeedSearchInput paramVec[]) {
+	for (size_t pnr=0; pnr<nparams; pnr++) {
+		SeedSearchInput &params = paramVec[pnr];
+		const InstantiatedSeed& seed = params.seed;
+		SeedAlignerSearchParams p(params, seed.cons[0], seed.cons[1], seed.cons[2], seed.overall, NULL);
+		searchSeedBi(p,0);
+	} 
 }
 
 inline void

--- a/aligner_seed.cpp
+++ b/aligner_seed.cpp
@@ -498,10 +498,10 @@ void SeedAligner::searchAllSeeds(
 	mcache.reserve(sr.numOffs()*2);
 	paramVec.reserve(sr.numOffs()*2*16); // assume no more than 16 iss per cache, on average
 
-	// For each instantiated seed
-	for(int i = 0; i < (int)sr.numOffs(); i++) {
-		for(int fwi = 0; fwi < 2; fwi++) {
-			bool fw = (fwi == 0);
+	for(int fwi = 0; fwi < 2; fwi++) {
+		bool fw = (fwi == 0);
+		// For each instantiated seed
+		for(int i = 0; i < (int)sr.numOffs(); i++) {
 			assert(sr.repOk(&cache.current()));
 			EList<InstantiatedSeed>& iss = sr.instantiatedSeeds(fw, i);
 			if(iss.empty()) {

--- a/aligner_seed.cpp
+++ b/aligner_seed.cpp
@@ -503,7 +503,6 @@ void SeedAligner::searchAllSeeds(
 			QVal qv;
 			const BTDnaString& seq  = sr.seqs(fw)[i];  // seed sequence
 			const BTString& qual = sr.quals(fw)[i]; // seed qualities
-			fw_   = fw;               // seed orientation
 			// Tell the cache that we've started aligning, so the cache can
 			// expect a series of on-the-fly updates
 			int ret = cache.beginAlign(seq, qual, qv);
@@ -1225,6 +1224,7 @@ bool
 SeedAligner::extendAndReportHit(
 	const BTDnaString& seq,  // sequence of current seed
 	size_t off,                          // offset of seed currently being searched
+	bool fw,                             // orientation of seed currently being searched
 	TIndexOffU topf,                     // top in BWT
 	TIndexOffU botf,                     // bot in BWT
 	TIndexOffU topb,                     // top in BWT'
@@ -1240,7 +1240,7 @@ SeedAligner::extendAndReportHit(
 		const Ebwt *ebwt = ebwtFw_;
 		assert(ebwt != NULL);
 		// Extend left using forward index
-		const BTDnaString& seq = fw_ ? read_->patFw : read_->patRc;
+		const BTDnaString& seq = fw ? read_->patFw : read_->patRc;
 		// See what we get by extending 
 		TIndexOffU top = topf, bot = botf;
 		t[0] = t[1] = t[2] = t[3] = 0;
@@ -1296,7 +1296,7 @@ SeedAligner::extendAndReportHit(
 		const Ebwt *ebwt = ebwtBw_;
 		assert(ebwt != NULL);
 		// Extend right using backward index
-		const BTDnaString& seq = fw_ ? read_->patFw : read_->patRc;
+		const BTDnaString& seq = fw ? read_->patFw : read_->patRc;
 		// See what we get by extending 
 		TIndexOffU top = topb, bot = botb;
 		t[0] = t[1] = t[2] = t[3] = 0;

--- a/aligner_seed.cpp
+++ b/aligner_seed.cpp
@@ -1914,7 +1914,9 @@ SeedAligner::searchSeedBi(const size_t nparams, SeedAligner::SeedAlignerSearchPa
 			assert_gt(sstate.b[c], 0);
 		}
 		assert(ebwtBw_ == NULL || sstate.bf[c]-sstate.tf[c] == sstate.bb[c]-sstate.tb[c]);
+#ifndef NDEBUG
 		sstate.assertLeqAndSetLastTot(sstate.bf[c]-sstate.tf[c]);
+#endif
 		if(sstate.b[c] == sstate.t[c]) {
 			sstate.done = true;
 			nleft--;

--- a/aligner_seed.h
+++ b/aligner_seed.h
@@ -1766,7 +1766,7 @@ protected:
 	 * we're done, which actually adds the hit to the cache.  Returns result from
 	 * calling reportHit().
 	 */
-	bool extendAndReportHit(
+	void extendAndReportHit(
 		SeedSearchCache &cache,              // local seed alignment cache
 		size_t off,                          // offset of seed currently being searched
 		bool fw,                             // orientation of seed currently being searched
@@ -1778,10 +1778,9 @@ protected:
 		DoublyLinkedList<Edit> *prevEdit); // previous edit
 
 	/**
-	 * Report a seed hit found by searchSeedBi() by adding it to the cache.  Return
-	 * false if the hit could not be reported because of, e.g., cache exhaustion.
+	 * Report a seed hit found by searchSeedBi() by adding it to the cache.
 	 */
-	bool reportHit(
+	void reportHit(
 		SeedSearchCache &cache,  // local seed alignment cache
 		TIndexOffU topf,         // top in BWT
 		TIndexOffU botf,         // bot in BWT
@@ -1793,12 +1792,12 @@ protected:
 	/**
 	 * Given an instantiated seed (in s_ and other fields), search
 	 */
-	bool searchSeedBi(SeedSearchInput &params);
+	void searchSeedBi(SeedSearchInput &params);
 	
 	/**
 	 * Main, recursive implementation of the seed search.
 	 */
-	bool searchSeedBi(
+	void searchSeedBi(
 		SeedSearchInput &params,
 		int step,                // depth into steps_[] array
 		int depth,               // recursion depth

--- a/aligner_seed.h
+++ b/aligner_seed.h
@@ -1573,6 +1573,7 @@ protected:
 	bool extendAndReportHit(
 		const BTDnaString& seq,              // sequence of current seed
 		size_t off,                          // offset of seed currently being searched
+		bool fw,                             // orientation of seed currently being searched
 		TIndexOffU topf,                     // top in BWT
 		TIndexOffU botf,                     // bot in BWT
 		TIndexOffU topb,                     // top in BWT'
@@ -1647,9 +1648,6 @@ protected:
 	const InstantiatedSeed* s_;// current instantiated seed
 	
 	const Read* read_;         // read whose seeds are currently being aligned
-	
-	// The following are set just before a call to searchSeedBi()
-	bool fw_;                  // orientation of seed currently being searched
 	
 	EList<Edit> edits_;        // temporary place to sort edits
 	AlignmentCacheIface *ca_;  // local alignment cache for seed alignments

--- a/aligner_seed.h
+++ b/aligner_seed.h
@@ -1783,14 +1783,10 @@ protected:
 	{ reportHit(cache, bwt.topf, bwt.botf, bwt.topb, bwt.botb, len, prevEdit); }
 
 	/**
+	 * Main, recursive implementation of the seed search.
 	 * Given a vector of instantiated seeds, search
 	 */
 	void searchSeedBi(const size_t nparams, SeedAlignerSearchParams paramVec[]);
-	
-	/**
-	 * Main, recursive implementation of the seed search.
-	 */
-	void searchSeedBi(SeedAlignerSearchParams &p);
 
 	// helper function
 	bool startSearchSeedBi(SeedAlignerSearchParams &p);

--- a/aligner_seed.h
+++ b/aligner_seed.h
@@ -214,7 +214,7 @@ struct Constraint {
 	 * are helpful to resolve instances where two search roots would
 	 * otherwise overlap in what alignments they can find.
 	 */
-	bool acceptable() {
+	bool acceptable() const {
 		assert(instantiated);
 		return edits   <= editsCeil &&
 		       mms     <= mmsCeil   &&
@@ -1809,7 +1809,23 @@ protected:
 		Constraint c2,         // constraints to enforce in seed zone 2
 		Constraint overall,    // overall constraints
 		DoublyLinkedList<Edit> *prevEdit);  // previous edit
-	
+
+	// helper function
+	bool startSearchSeedBi(
+		SeedSearchInput &params,
+		int depth,            // recursion depth
+		const Constraint &c0, // constraints to enforce in seed zone 0
+		const Constraint &c1, // constraints to enforce in seed zone 1
+		const Constraint &c2, // constraints to enforce in seed zone 2
+		DoublyLinkedList<Edit> *prevEdit,  // previous edit
+		int &step,            // depth into steps_[] array
+		TIndexOffU &topf,     // top in BWT
+		TIndexOffU &botf,     // bot in BWT
+		TIndexOffU &topb,     // top in BWT'
+		TIndexOffU &botb,     // bot in BWT'
+		SideLocus &tloc,      // locus for top (perhaps unititialized)
+		SideLocus &bloc);     // locus for bot (perhaps unititialized)
+
 	/**
 	 * Get tloc and bloc ready for the next step.
 	 */

--- a/aligner_seed.h
+++ b/aligner_seed.h
@@ -1644,6 +1644,9 @@ public:
 		const InstantiatedSeed& _seed    // current instantiated seed
 	) : cache(_cache), seed(_seed) {}
 
+	SeedSearchInput(SeedSearchInput &other) = default;
+	SeedSearchInput(SeedSearchInput &&other) = default;
+
 	SeedSearchCache &cache;        // local seed alignment cache
 	const InstantiatedSeed& seed;  // current instantiated seed
 };
@@ -1804,15 +1807,13 @@ protected:
 	 * Main, recursive implementation of the seed search.
 	 */
 	void searchSeedBi(
-		SeedSearchInput &params,
-		int depth,               // recursion depth
-		SeedAlignerSearchParams &p); // all the remaining params
+		SeedAlignerSearchParams &p,
+		int depth);               // recursion depth
 
 	// helper function
 	bool startSearchSeedBi(
-		SeedSearchInput &params,
-		int depth,            // recursion depth
-		SeedAlignerSearchParams &p); // all the remaining params
+		SeedAlignerSearchParams &p,
+		int depth);            // recursion depth
 
 	/**
 	 * Get tloc and bloc ready for the next step.

--- a/aligner_seed.h
+++ b/aligner_seed.h
@@ -1805,7 +1805,6 @@ protected:
 	 */
 	void searchSeedBi(
 		SeedSearchInput &params,
-		int step,                // depth into steps_[] array
 		int depth,               // recursion depth
 		SeedAlignerSearchParams &p); // all the remaining params
 
@@ -1813,7 +1812,6 @@ protected:
 	bool startSearchSeedBi(
 		SeedSearchInput &params,
 		int depth,            // recursion depth
-		int &step,            // depth into steps_[] array
 		SeedAlignerSearchParams &p); // all the remaining params
 
 	/**

--- a/aligner_seed.h
+++ b/aligner_seed.h
@@ -1555,9 +1555,8 @@ public:
 
 	// Same semantics as std::vector
 	void reserve(size_t new_cap) { cacheVec.reserve(new_cap); }
-
 	size_t size() const {return cacheVec.size(); }
-
+	void clear() { cacheVec.clear(); }
 	void pop_back() { cacheVec.pop_back(); }
 
 	// Access one of the search caches

--- a/aligner_seed.h
+++ b/aligner_seed.h
@@ -1790,14 +1790,10 @@ protected:
 	/**
 	 * Main, recursive implementation of the seed search.
 	 */
-	void searchSeedBi(
-		SeedAlignerSearchParams &p,
-		int depth);               // recursion depth
+	void searchSeedBi(SeedAlignerSearchParams &p);
 
 	// helper function
-	bool startSearchSeedBi(
-		SeedAlignerSearchParams &p,
-		int depth);            // recursion depth
+	bool startSearchSeedBi(SeedAlignerSearchParams &p);
 
 	/**
 	 * Get tloc and bloc ready for the next step.

--- a/aligner_seed.h
+++ b/aligner_seed.h
@@ -1799,9 +1799,9 @@ protected:
 	{ reportHit(cache, bwt.topf, bwt.botf, bwt.topb, bwt.botb, len, prevEdit); }
 
 	/**
-	 * Given an instantiated seed (in s_ and other fields), search
+	 * Given a vector of instantiated seeds, search
 	 */
-	void searchSeedBi(SeedSearchInput &params);
+	void searchSeedBi(const size_t nparams, SeedSearchInput paramVec[]);
 	
 	/**
 	 * Main, recursive implementation of the seed search.

--- a/aligner_seed.h
+++ b/aligner_seed.h
@@ -1551,6 +1551,7 @@ public:
 		// emplace_back does not return reference until c++17
 		AlignmentCacheIface& cacheEl = cacheVec.back();
 		srcacheVec.emplace_back(cacheEl, seq, qual);
+		// TODO: handle eventual exception
 	}
 
 	// Same semantics as std::vector
@@ -1561,6 +1562,11 @@ public:
 
 	size_t size() const {return srcacheVec.size(); }
 
+	void pop_back() {
+		srcacheVec.pop_back();
+		cacheVec.pop_back();
+	}
+
 	// Access one of the search caches
 	const SeedSearchCache& operator[](size_t idx) const { return srcacheVec[idx]; }
 	SeedSearchCache& operator[](size_t idx) { return srcacheVec[idx]; }
@@ -1570,6 +1576,17 @@ protected:
 
 	std::vector<AlignmentCacheIface> cacheVec;  // cache object vector
 	std::vector<SeedSearchCache>   srcacheVec;  // search wrapper vector, maps to element above
+};
+
+class SeedSearchInput {
+public:
+	SeedSearchInput(
+		SeedSearchCache &_cache,         // local seed alignment cache
+		const InstantiatedSeed& _seed    // current instantiated seed
+	) : cache(_cache), seed(_seed) {}
+
+	SeedSearchCache &cache;        // local seed alignment cache
+	const InstantiatedSeed& seed;  // current instantiated seed
 };
 
 
@@ -1716,16 +1733,13 @@ protected:
 	/**
 	 * Given an instantiated seed (in s_ and other fields), search
 	 */
-	bool searchSeedBi(
-		SeedSearchCache &cache,         // local seed alignment cache
-		const InstantiatedSeed& seed);  // current instantiated seed
+	bool searchSeedBi(SeedSearchInput &params);
 	
 	/**
 	 * Main, recursive implementation of the seed search.
 	 */
 	bool searchSeedBi(
-		SeedSearchCache &cache,  // local seed alignment cache
-		const InstantiatedSeed& seed,  // current instantiated seed
+		SeedSearchInput &params,
 		int step,                // depth into steps_[] array
 		int depth,               // recursion depth
 		TIndexOffU topf,         // top in BWT

--- a/aligner_seed.h
+++ b/aligner_seed.h
@@ -1572,6 +1572,7 @@ protected:
 	 */
 	bool extendAndReportHit(
 		const BTDnaString& seq,              // sequence of current seed
+		size_t off,                          // offset of seed currently being searched
 		TIndexOffU topf,                     // top in BWT
 		TIndexOffU botf,                     // bot in BWT
 		TIndexOffU topb,                     // top in BWT'
@@ -1648,7 +1649,6 @@ protected:
 	const Read* read_;         // read whose seeds are currently being aligned
 	
 	// The following are set just before a call to searchSeedBi()
-	size_t off_;               // offset of seed currently being searched
 	bool fw_;                  // orientation of seed currently being searched
 	
 	EList<Edit> edits_;        // temporary place to sort edits

--- a/aligner_seed.h
+++ b/aligner_seed.h
@@ -1599,7 +1599,8 @@ protected:
 	 */
 	bool searchSeedBi(
 		const BTDnaString& seq,  // sequence of current seed
-		const BTString& qual);    // quality string for current seed
+		const BTString& qual,    // quality string for current seed
+		const InstantiatedSeed& seed);  // current instantiated seed
 	
 	/**
 	 * Main, recursive implementation of the seed search.
@@ -1607,6 +1608,7 @@ protected:
 	bool searchSeedBi(
 		const BTDnaString& seq,  // sequence of current seed
 		const BTString& qual,    // quality string for current seed
+		const InstantiatedSeed& seed,  // current instantiated seed
 		int step,                // depth into steps_[] array
 		int depth,               // recursion depth
 		TIndexOffU topf,         // top in BWT
@@ -1625,6 +1627,7 @@ protected:
 	 * Get tloc and bloc ready for the next step.
 	 */
 	inline void nextLocsBi(
+		const InstantiatedSeed& seed, // current instantiated seed
 		SideLocus& tloc,            // top locus
 		SideLocus& bloc,            // bot locus
 		TIndexOffU topf,              // top in BWT
@@ -1634,6 +1637,7 @@ protected:
 		int step);                  // step to get ready for
 	
 	inline void prefetchNextLocsBi(
+		const InstantiatedSeed& seed, // current instantiated seed
 		TIndexOffU topf,              // top in BWT
 		TIndexOffU botf,              // bot in BWT
 		TIndexOffU topb,              // top in BWT'
@@ -1645,7 +1649,6 @@ protected:
 	const Ebwt* ebwtFw_;       // forward index (BWT)
 	const Ebwt* ebwtBw_;       // backward/mirror index (BWT')
 	const Scoring* sc_;        // scoring scheme
-	const InstantiatedSeed* s_;// current instantiated seed
 	
 	const Read* read_;         // read whose seeds are currently being aligned
 	

--- a/aligner_seed.h
+++ b/aligner_seed.h
@@ -1455,8 +1455,6 @@ struct SeedSearchMetrics {
 	MUTEX_T  mutex_m;
 };
 
-class SeedAlignerSearchParams;
-
 /**
  * Wrap the search cache with all the relevant objects
  */
@@ -1637,21 +1635,6 @@ protected:
 	std::vector<CacheEl> cacheVec;
 };
 
-class SeedSearchInput {
-public:
-	SeedSearchInput(
-		SeedSearchCache &_cache,         // local seed alignment cache
-		const InstantiatedSeed& _seed    // current instantiated seed
-	) : cache(_cache), seed(_seed) {}
-
-	SeedSearchInput(SeedSearchInput &other) = default;
-	SeedSearchInput(SeedSearchInput &&other) = default;
-
-	SeedSearchCache &cache;        // local seed alignment cache
-	const InstantiatedSeed& seed;  // current instantiated seed
-};
-
-
 /**
  * Given an index and a seeding scheme, searches for seed hits.
  */
@@ -1760,6 +1743,7 @@ public:
 		SeedSearchMetrics& met);   // metrics
 
 protected:
+	class SeedAlignerSearchParams;
 
 	/**
 	 * Report a seed hit found by searchSeedBi(), but first try to extend it out in
@@ -1801,7 +1785,7 @@ protected:
 	/**
 	 * Given a vector of instantiated seeds, search
 	 */
-	void searchSeedBi(const size_t nparams, SeedSearchInput paramVec[]);
+	void searchSeedBi(const size_t nparams, SeedAlignerSearchParams paramVec[]);
 	
 	/**
 	 * Main, recursive implementation of the seed search.

--- a/aligner_seed.h
+++ b/aligner_seed.h
@@ -1558,7 +1558,7 @@ protected:
                 	TIndexOffU _topb,            // top in BWT' index
                 	TIndexOffU _botb             // bot in BWT' index
 			) :
-			ASSERT_ONLY(tm(), )
+			ASSERT_ONLY(tmp(), )
 			sak(rfseq ASSERT_ONLY(, tmp)),
 			topf(_topf), botf(_botf), topb(_topb), botb(_botb) 
 		{}

--- a/aligner_seed.h
+++ b/aligner_seed.h
@@ -1571,6 +1571,7 @@ protected:
 	 * calling reportHit().
 	 */
 	bool extendAndReportHit(
+		const BTDnaString& seq,              // sequence of current seed
 		TIndexOffU topf,                     // top in BWT
 		TIndexOffU botf,                     // bot in BWT
 		TIndexOffU topb,                     // top in BWT'
@@ -1583,6 +1584,7 @@ protected:
 	 * false if the hit could not be reported because of, e.g., cache exhaustion.
 	 */
 	bool reportHit(
+		const BTDnaString& seq,  // sequence of current seed
 		TIndexOffU topf,         // top in BWT
 		TIndexOffU botf,         // bot in BWT
 		TIndexOffU topb,         // top in BWT'
@@ -1593,14 +1595,18 @@ protected:
 	/**
 	 * Given an instantiated seed (in s_ and other fields), search
 	 */
-	bool searchSeedBi();
+	bool searchSeedBi(
+		const BTDnaString& seq,  // sequence of current seed
+		const BTString& qual);    // quality string for current seed
 	
 	/**
 	 * Main, recursive implementation of the seed search.
 	 */
 	bool searchSeedBi(
-		int step,              // depth into steps_[] array
-		int depth,             // recursion depth
+		const BTDnaString& seq,  // sequence of current seed
+		const BTString& qual,    // quality string for current seed
+		int step,                // depth into steps_[] array
+		int depth,               // recursion depth
 		TIndexOffU topf,         // top in BWT
 		TIndexOffU botf,         // bot in BWT
 		TIndexOffU topb,         // top in BWT'
@@ -1642,8 +1648,6 @@ protected:
 	const Read* read_;         // read whose seeds are currently being aligned
 	
 	// The following are set just before a call to searchSeedBi()
-	const BTDnaString* seq_;   // sequence of current seed
-	const BTString* qual_;     // quality string for current seed
 	size_t off_;               // offset of seed currently being searched
 	bool fw_;                  // orientation of seed currently being searched
 	

--- a/aligner_seed.h
+++ b/aligner_seed.h
@@ -1455,6 +1455,8 @@ struct SeedSearchMetrics {
 	MUTEX_T  mutex_m;
 };
 
+class SeedAlignerSearchParams;
+
 /**
  * Wrap the search cache with all the relevant objects
  */
@@ -1805,27 +1807,14 @@ protected:
 		SeedSearchInput &params,
 		int step,                // depth into steps_[] array
 		int depth,               // recursion depth
-		BwtTopBot bwt,         // The 4 BWT idxs
-		SideLocus tloc,        // locus for top (perhaps unititialized)
-		SideLocus bloc,        // locus for bot (perhaps unititialized)
-		Constraint c0,         // constraints to enforce in seed zone 0
-		Constraint c1,         // constraints to enforce in seed zone 1
-		Constraint c2,         // constraints to enforce in seed zone 2
-		Constraint overall,    // overall constraints
-		DoublyLinkedList<Edit> *prevEdit);  // previous edit
+		SeedAlignerSearchParams &p); // all the remaining params
 
 	// helper function
 	bool startSearchSeedBi(
 		SeedSearchInput &params,
 		int depth,            // recursion depth
-		const Constraint &c0, // constraints to enforce in seed zone 0
-		const Constraint &c1, // constraints to enforce in seed zone 1
-		const Constraint &c2, // constraints to enforce in seed zone 2
-		DoublyLinkedList<Edit> *prevEdit,  // previous edit
 		int &step,            // depth into steps_[] array
-		BwtTopBot &bwt,        // The 4 BWT idxs
-		SideLocus &tloc,      // locus for top (perhaps unititialized)
-		SideLocus &bloc);     // locus for bot (perhaps unititialized)
+		SeedAlignerSearchParams &p); // all the remaining params
 
 	/**
 	 * Get tloc and bloc ready for the next step.

--- a/bt2_idx.h
+++ b/bt2_idx.h
@@ -381,8 +381,9 @@ struct SideLocus {
 		const TIndexOffU sByteOff = sideNum * sideSz;
 		if (prefetch) {
 			__builtin_prefetch(ebwt + sByteOff);
-#if (OFF_SIZE>4)
 			__builtin_prefetch(ebwt + sByteOff + 64); //64 byte cache lines
+#if (OFF_SIZE>4)
+			__builtin_prefetch(ebwt + sByteOff + 2*64);
 #endif
                 }
 
@@ -405,15 +406,17 @@ struct SideLocus {
 		const TIndexOffU sideNum     = row / (48*OFF_SIZE);
 		const TIndexOffU sideByteOff = sideNum * sideSz;
 		__builtin_prefetch(ebwt + sideByteOff);
-#if (OFF_SIZE>4)
 		__builtin_prefetch(ebwt + sideByteOff + 64); //64 byte cache lines
+#if (OFF_SIZE>4)
+		__builtin_prefetch(ebwt + sideByteOff + 2*64);
 #endif
 	}
 
 	void prefetch(const uint8_t* ebwt) const {
                 __builtin_prefetch(ebwt + _sideByteOff);
-#if (OFF_SIZE>4)
                 __builtin_prefetch(ebwt + _sideByteOff + 64); //64 byte cache lines
+#if (OFF_SIZE>4)
+                __builtin_prefetch(ebwt + _sideByteOff + 2*64);
 #endif
 	}
 

--- a/bt2_idx.h
+++ b/bt2_idx.h
@@ -2005,9 +2005,12 @@ public:
 	 * given side up to (but not including) the given byte/bitpair (by/bp).
 	 * Count for 'a' goes in arrs[0], 'c' in arrs[1], etc.
 	 *
-	 * This is a performance-critical function.  This is the top search-
+	 * This is a performance-critical function.  This used to be the top search-
 	 * related hit in the time profile.
-	 * The bottleneck seems to be cache misses due to random memory access pattern.
+	 * The bottleneck was due to cache misses due to random memory access pattern.
+	 *
+	 * The use of prefetch instructions in initFromRow, when applied enough in advance,
+	 * mostly eliminate the cache misses. 
 	 */
 	inline void countUpToEx(const SideLocus& l, TIndexOffU* arrs) const {
 		int i = 0;

--- a/bt2_idx.h
+++ b/bt2_idx.h
@@ -1387,6 +1387,12 @@ public:
 			i);
 	}
 
+	void ftabHiPrefetch(TIndexOffU i) const {
+		Ebwt::ftabHiPrefetch(
+			ftab(),
+			i);
+	}
+
 	/**
 	 * Get "high interpretation" of ftab entry at index i.  The high
 	 * interpretation of a regular ftab entry is just the entry
@@ -1414,6 +1420,13 @@ public:
 			}
 		}
 
+	static void ftabHiPrefetch(
+		const TIndexOffU *ftab,
+		TIndexOffU i)
+		{
+			__builtin_prefetch(&(ftab[i]));
+		}
+
 	/**
 	 * Non-static facade for static function ftabLo.
 	 */
@@ -1426,6 +1439,32 @@ public:
 			_eh._eftabLen,
 			i);
 	}
+
+	void ftabLoPrefetch(TIndexOffU i) const {
+		Ebwt::ftabLoPrefetch(
+			ftab(),
+			i);
+	}
+
+	/**
+	 * Get low and high bound of ftab range.
+	 */
+	void
+	ftabLoHi(
+		TIndexOffU i,
+		TIndexOffU& top,
+		TIndexOffU& bot) const
+		{
+			top = ftabHi(i);
+			bot = ftabLo(i+1);
+			assert_geq(bot, top);
+		}
+
+	void ftabLoHiPrefetch(TIndexOffU i) const
+		{
+			ftabHiPrefetch(i);
+			ftabLoPrefetch(i+1);
+		}
 
 	/**
 	 * Get low bound of ftab range.
@@ -1460,9 +1499,7 @@ public:
 			if(fi == std::numeric_limits<TIndexOffU>::max()) {
 				return false;
 			}
-			top = ftabHi(fi);
-			bot = ftabLo(fi+1);
-			assert_geq(bot, top);
+			ftabLoHi(fi, top, bot);
 			return true;
 		}
 
@@ -1491,6 +1528,13 @@ public:
 				assert_lt(efIdx*2+1, eftabLen);
 				return eftab[efIdx*2];
 			}
+		}
+
+	static void ftabLoPrefetch(
+		const TIndexOffU *ftab,
+		TIndexOffU i)
+		{
+			__builtin_prefetch(&(ftab[i]));
 		}
 
 	/**

--- a/bt2_idx.h
+++ b/bt2_idx.h
@@ -1899,11 +1899,13 @@ public:
 	 * Counts the number of occurrences of character 'c' in the given Ebwt
 	 * side up to (but not including) the given byte/bitpair (by/bp).
 	 *
-	 * This is a performance-critical function.  This is the top search-
+	 * This is a performance-critical function.  This used to be the top search-
 	 * related hit in the time profile.
-	 * The bottleneck seems to be cache misses due to random memory access pattern.
+	 * The bottleneck was due to cache misses due to random memory access pattern.
 	 *
-	 * Function gets 11.09% in profile
+	 * The use of prefetch instructions in initFromRow, when applied enough in advance,
+	 * mostly eliminate the cache misses. 
+	 *
 	 */
 	inline TIndexOffU countUpTo(const SideLocus& l, int c) const { // @double-check
 		// Count occurrences of c in each 64-bit (using bit trickery);


### PR DESCRIPTION
SeedAligner::searchSeedBi used to be completely memory bound (indirectly via Ebwt::countUpToEx), due to irregular memory access pattern.
By interleaving many searchSeedBi loops in a single invocation, the prefetch now has enough latency to be effective.

This required a refactoring of the loop in SeedAligner::searchAllSeeds.

A similar change was made in SeedAligner::exactSweep, too.