### PR TITLE
Make ZSTD support work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,6 +182,7 @@ SEARCH_CPPS :=  qual.cpp pat.cpp sam.cpp \
 ifeq (1, $(WITH_ZSTD))
   LDLIBS += -lzstd
   SHARED_CPPS += zstd_decompress.cpp
+  CXXFLAGS += -DWITH_ZSTD
 endif
 
 SEARCH_CPPS_MAIN := $(SEARCH_CPPS) bowtie_main.cpp

--- a/filebuf.h
+++ b/filebuf.h
@@ -136,7 +136,7 @@ public:
 	int get() {
 		assert(_in != NULL || _zIn != NULL || _inf != NULL || _ins != NULL);
 #ifdef WITH_ZSTD
-		assert(zstdIn != NULL)
+		assert(_zstdIn != NULL);
 #endif
 		int c = peek();
 		if(c != -1) {
@@ -265,7 +265,7 @@ public:
 	int peek() {
 		assert(_in != NULL || _zIn != NULL || _inf != NULL || _ins != NULL);
 #ifdef WITH_ZSTD
-		assert(zstdIn != NULL);
+		assert(_zstdIn != NULL);
 #endif
 		assert_leq(_cur, _buf_sz);
 		if(_cur == _buf_sz) {


### PR DESCRIPTION
Hi,

Thanks for adding native Zstandard support. But current implementation doesn't work completely:
* the Make WITH_ZSTD flag isn't added to CXXFLAGS in the Makefile (so conditional code doesn't get compiled)
* Small syntax errors in `filebuf.h`. I got the error `error: ‘zstdIn’ was not declared in this scope;`

Patch has been tested on zst-compressed FASTQ files.
Please comment/merge.