### PR TITLE
Make reading of buffers fully asynchronous

### DIFF
--- a/bt2_search.cpp
+++ b/bt2_search.cpp
@@ -4718,7 +4718,7 @@ static void multiseedSearch(
 	}
 
 	// Important: Need at least nthreads+1 elements, more is OK
-	PatternSourceReadAheadFactory readahead_factory(patsrc,pp,2*nthreads+1,0);
+	PatternSourceReadAheadFactory readahead_factory(patsrc,pp,2*nthreads+1);
 	multiseed_readahead_factory = &readahead_factory;
 
 	// Start the metrics thread

--- a/bt2_search.cpp
+++ b/bt2_search.cpp
@@ -1776,6 +1776,7 @@ static void parseOptions(int argc, const char **argv) {
 
 static const char *argv0 = NULL;
 
+#if 0
 /// Create a PatternSourcePerThread for the current thread according
 /// to the global params and return a pointer to it
 static PatternSourcePerThreadFactory*
@@ -1789,11 +1790,11 @@ createPatsrcFactory(
 	assert(patsrcFact != NULL);
 	return patsrcFact;
 }
+#endif
 
 #define PTHREAD_ATTRS (PTHREAD_CREATE_JOINABLE | PTHREAD_CREATE_DETACHED)
 
-static PatternComposer*         multiseed_patsrc;
-static PatternParams            multiseed_pp;
+static PatternSourceReadAheadFactory* multiseed_readahead_factory;
 static Ebwt*                    multiseed_ebwtFw;
 static Ebwt*                    multiseed_ebwtBw;
 static Scoring*                 multiseed_sc;
@@ -2983,8 +2984,7 @@ static void multiseedSearchWorker(void *vp) {
 	int tid = p->tid;
 	assert(multiseed_ebwtFw != NULL);
 	assert(multiseedMms == 0 || multiseed_ebwtBw != NULL);
-	PatternComposer&        patsrc   = *multiseed_patsrc;
-	PatternParams           pp       = multiseed_pp;
+	PatternSourceReadAheadFactory& readahead_factory =  *multiseed_readahead_factory;
 	const Ebwt&             ebwtFw   = *multiseed_ebwtFw;
 	const Ebwt*             ebwtBw   = multiseed_ebwtBw;
 	const Scoring&          sc       = *multiseed_sc;
@@ -3013,8 +3013,6 @@ static void multiseedSearchWorker(void *vp) {
 		// problems, or generally characterize performance.
 
 		//const BitPairReference& refs   = *multiseed_refs;
-		unique_ptr<PatternSourcePerThreadFactory> patsrcFact(createPatsrcFactory(patsrc, pp, tid));
-		unique_ptr<PatternSourcePerThread> ps(patsrcFact->create());
 
 		// Thread-local cache for seed alignments
 		PtrWrap<AlignmentCache> scLocal;
@@ -3133,6 +3131,9 @@ static void multiseedSearchWorker(void *vp) {
 		int mergeival = 16;
 		bool done = false;
 		while(!done) {
+		   PatternSourceReadAhead psrah(readahead_factory);
+		   PatternSourcePerThread* const ps = psrah.ptr();
+                   do {
 			pair<bool, bool> ret = ps->nextReadPair();
 			bool success = ret.first;
 			done = ret.second;
@@ -4099,6 +4100,7 @@ static void multiseedSearchWorker(void *vp) {
 				metricsOfb, metricsStderr, true, &nametmp);
 			metricsPt.reset();
 		}
+	   } while (ps->nextReadPairReady()); // must read the whole cached buffer
 	} // while(true)
 
 	// One last metrics merge
@@ -4127,8 +4129,7 @@ static void multiseedSearchWorker_2p5(void *vp) {
 	int tid = p->tid;
 	assert(multiseed_ebwtFw != NULL);
 	assert(multiseedMms == 0 || multiseed_ebwtBw != NULL);
-	PatternComposer&        patsrc   = *multiseed_patsrc;
-	PatternParams           pp       = multiseed_pp;
+	PatternSourceReadAheadFactory& readahead_factory =  *multiseed_readahead_factory;
 	const Ebwt&             ebwtFw   = *multiseed_ebwtFw;
 	const Ebwt&             ebwtBw   = *multiseed_ebwtBw;
 	const Scoring&          sc       = *multiseed_sc;
@@ -4142,8 +4143,6 @@ static void multiseedSearchWorker_2p5(void *vp) {
 	// problems, or generally characterize performance.
 
 	ThreadCounter tc;
-	unique_ptr<PatternSourcePerThreadFactory> patsrcFact(createPatsrcFactory(patsrc, pp, tid));
-	unique_ptr<PatternSourcePerThread> ps(patsrcFact->create());
 
 	// Instantiate an object for holding reporting-related parameters.
 	ReportingParams rp(
@@ -4240,6 +4239,9 @@ static void multiseedSearchWorker_2p5(void *vp) {
 	int mergei = 0;
 	int mergeival = 16;
 	while(true) {
+	   PatternSourceReadAhead psrah(readahead_factory);
+	   PatternSourcePerThread* const ps = psrah.ptr();
+	   do {
 		pair<bool, bool> ret = ps->nextReadPair();
 		bool success = ret.first;
 		bool done = ret.second;
@@ -4451,6 +4453,7 @@ static void multiseedSearchWorker_2p5(void *vp) {
 				metricsOfb, metricsStderr, true, &nametmp);
 			metricsPt.reset();
 		}
+	   } while (ps->nextReadPairReady()); // must read the whole cached buffer
 	} // while(true)
 
 	// One last metrics merge
@@ -4646,8 +4649,6 @@ static void multiseedSearch(
 	Ebwt* ebwtBw,                 // index of mirror text
 	OutFileBuf *metricsOfb)
 {
-	multiseed_patsrc = &patsrc;
-	multiseed_pp = pp;
 	multiseed_msink  = &msink;
 	multiseed_ebwtFw = &ebwtFw;
 	multiseed_ebwtBw = ebwtBw;
@@ -4711,6 +4712,11 @@ static void multiseedSearch(
 			!noRefNames,  // load names?
 			startVerbose);
 	}
+
+	// Important: Need at least nthreads+1 elements, more is OK
+	PatternSourceReadAheadFactory readahead_factory(patsrc,pp,2*nthreads+1,0);
+	multiseed_readahead_factory = &readahead_factory;
+
 	// Start the metrics thread
 
 	std::atomic<int> all_threads_done;

--- a/bt2_search.cpp
+++ b/bt2_search.cpp
@@ -3133,8 +3133,12 @@ static void multiseedSearchWorker(void *vp) {
 		while(!done) {
 		   PatternSourceReadAhead psrah(readahead_factory);
 		   PatternSourcePerThread* const ps = psrah.ptr();
+		   bool firstPS = true;
                    do {
-			pair<bool, bool> ret = ps->nextReadPair();
+			pair<bool, bool> ret = firstPS ? 
+						psrah.readResult() : // nextReadPair was already called in the psrah constructor
+						ps->nextReadPair();
+			firstPS = false;
 			bool success = ret.first;
 			done = ret.second;
 			if(!success && done) {

--- a/pat.h
+++ b/pat.h
@@ -133,12 +133,11 @@ struct PatternParams {
  */
 struct PerThreadReadBuf {
 
-	PerThreadReadBuf(size_t max_buf, int tid) :
+	PerThreadReadBuf(size_t max_buf) :
 		max_buf_(max_buf),
 		bufa_(max_buf),
 		bufb_(max_buf),
-		rdid_(),
-		tid_(tid)
+		rdid_()
 	{
 		bufa_.resize(max_buf);
 		bufb_.resize(max_buf);
@@ -207,7 +206,6 @@ struct PerThreadReadBuf {
 	EList<Read> bufb_;	   // Read buffer for mate bs
 	size_t cur_buf_;	   // Read buffer currently active
 	TReadId rdid_;		   // index of read at offset 0 of bufa_/bufb_
-	int tid_;
 };
 
 extern void wrongQualityFormat(const BTString& read_name);
@@ -1155,9 +1153,9 @@ public:
 
 	PatternSourcePerThread(
 		PatternComposer& composer,
-		const PatternParams& pp, int tid) :
+		const PatternParams& pp) :
 		composer_(composer),
-		buf_(pp.max_buf, tid),
+		buf_(pp.max_buf),
 		pp_(pp),
 		last_batch_(false),
 		last_batch_size_(0) { }
@@ -1248,16 +1246,15 @@ class PatternSourcePerThreadFactory {
 public:
 	PatternSourcePerThreadFactory(
 		PatternComposer& composer,
-		const PatternParams& pp, int tid) :
+		const PatternParams& pp) :
 		composer_(composer),
-		pp_(pp),
-		tid_(tid) { }
+		pp_(pp) {}
 
 	/**
 	 * Create a new heap-allocated PatternSourcePerThreads.
 	 */
 	virtual PatternSourcePerThread* create() const {
-		return new PatternSourcePerThread(composer_, pp_, tid_);
+		return new PatternSourcePerThread(composer_, pp_);
 	}
 
 	/**
@@ -1267,7 +1264,7 @@ public:
 	virtual EList<PatternSourcePerThread*>* create(uint32_t n) const {
 		EList<PatternSourcePerThread*>* v = new EList<PatternSourcePerThread*>;
 		for(size_t i = 0; i < n; i++) {
-			v->push_back(new PatternSourcePerThread(composer_, pp_, tid_));
+			v->push_back(new PatternSourcePerThread(composer_, pp_));
 			assert(v->back() != NULL);
 		}
 		return v;
@@ -1279,7 +1276,6 @@ private:
 	/// Container for obtaining paired reads from PatternSources
 	PatternComposer& composer_;
 	const PatternParams& pp_;
-	int tid_;
 };
 
 class PatternSourceReadAheadFactory {
@@ -1292,8 +1288,8 @@ public:
 
 	PatternSourceReadAheadFactory(
 		PatternComposer& composer,
-		const PatternParams& pp, size_t n, int tid) :
-		psfact_(composer,pp,tid),
+		const PatternParams& pp, size_t n) :
+		psfact_(composer,pp),
 		psq_ready_(),
 		psq_idle_(psfact_,n),
 		n_(n),


### PR DESCRIPTION
DIsk IO can be overlapped with compute, avoiding artificial serialization.
Since true async IO does not exist, I add a dedicated thread that reads for the compute threads in parallel with the compute.