### PR TITLE
Typo in command line section of the MANUAL

### DIFF
--- a/MANUAL
+++ b/MANUAL
@@ -775,7 +775,7 @@ alignment to be considered valid, and x is the read length.
 
 Usage
 
-    bowtie2 [options]* -x <bt2-idx> {-1 <m1> -2 <m2> | -U <r> | --interleaved <i> | --sra-acc <acc> | b <bam>} -S [<sam>]
+    bowtie2 [options]* -x <bt2-idx> {-1 <m1> -2 <m2> | -U <r> | --interleaved <i> | --sra-acc <acc> | -b <bam>} -S [<sam>]
 
 Main arguments
 


### PR DESCRIPTION
A minus sign was missing on the bam switch