### PR TITLE
Adds a --kbest argument to allow reporting k-best alignments

### DIFF
--- a/aln_sink.h
+++ b/aln_sink.h
@@ -219,9 +219,10 @@ struct ReportingParams {
 		THitInt pengap_,
 		bool msample_,
 		bool discord_,
-		bool mixed_)
+		bool mixed_,
+		bool kbest_)
 	{
-		init(khits_, mhits_, pengap_, msample_, discord_, mixed_);
+		init(khits_, mhits_, pengap_, msample_, discord_, mixed_, kbest_);
 	}
 
 	void init(
@@ -230,7 +231,8 @@ struct ReportingParams {
 		THitInt pengap_,
 		bool msample_,
 		bool discord_,
-		bool mixed_)
+		bool mixed_,
+		bool kbest_)
 	{
 		khits   = khits_;     // -k (or high if -a)
 		mhits   = ((mhits_ == 0) ? std::numeric_limits<THitInt>::max() : mhits_);
@@ -238,6 +240,7 @@ struct ReportingParams {
 		msample = msample_;
 		discord = discord_;
 		mixed   = mixed_;
+		kbest   = kbest_;
 	}
 
 #ifndef NDEBUG
@@ -310,6 +313,10 @@ struct ReportingParams {
 	// are paired-end alignments for a paired-end read, or if the number of
 	// paired-end alignments exceeds the -m ceiling.
 	bool mixed;
+
+	// true iff both -k and --kbest are specified and we only report the best
+	// scoring alignments among the top-k hits
+	bool kbest;
 };
 
 /**
@@ -1027,7 +1034,8 @@ public:
 		RandomSource&      rnd,         // pseudo-random generator
 		ReportingMetrics&  met,         // reporting metrics
 		const PerReadMetrics& prm,      // per-read metrics
-		const Scoring& sc,              // scoring scheme
+		const Scoring&     sc,          // scoring scheme
+		bool               selectBest,  // only report the top-scoring alignments
 		bool suppressSeedSummary = true,
 		bool suppressAlignments = false,
 		bool scUnMapped = false,
@@ -1234,6 +1242,7 @@ protected:
 		EList<size_t>&       select, // prioritized list to put results in
 		const EList<AlnRes>* rs1u,   // alignments to select from (mate 1)
 		const EList<AlnRes>* rs2u,   // alignments to select from (mate 2, or NULL)
+		const bool           selectBest, // only select the top-scoring alignments
 		AlnScore&            bestUScore,
 		AlnScore&            bestUDist,
 		AlnScore&            bestP1Score,

--- a/bt2_search.cpp
+++ b/bt2_search.cpp
@@ -1291,7 +1291,6 @@ static void parseOption(int next_option, const char *arg) {
 	}
 	case ARG_K_BEST: {
 		kbest = true;
-		cerr << "Set -kbest to true" << endl;
 		break;
 	}
 	case ARG_VERBOSE: gVerbose = 1; break;
@@ -1801,6 +1800,11 @@ static void parseOptions(int argc, const char **argv) {
 		     << "); setting mismatches to " << (multiseedMms-1)
 		     << " instead" << endl;
 		multiseedMms = multiseedLen-1;
+	}
+	if (kbest && khits == 1) {
+		cerr << "Warning: --kbest is set while -k is not set or set to 1 "
+		     << "(the default value). The kbest mode would not make a "
+			 << "difference when -k is <= 1." << endl;
 	}
 	sam_print_zm = sam_print_zm && bowtie2p5;
 #ifndef NDEBUG
@@ -4126,6 +4130,7 @@ static void multiseedSearchWorker(void *vp) {
 					rpm,                  // reporting metrics
 					prm,                  // per-read metrics
 					sc,                   // scoring scheme
+					kbest,                // only reports the top-scoring alignments
 					!seedSumm,            // suppress seed summaries?
 					seedSumm,             // suppress alignments?
 					scUnMapped,           // Consider soft-clipped bases unmapped when calculating TLEN
@@ -4483,6 +4488,7 @@ static void multiseedSearchWorker_2p5(void *vp) {
 				rpm,                  // reporting metrics
 				prm,                  // per-read metrics
 				sc,                   // scoring scheme
+				kbest,                // only reports the top-scoring alignments
 				!seedSumm,            // suppress seed summaries?
 				seedSumm,             // suppress alignments?
 				scUnMapped,           // Consider soft-clipped bases unmapped when calculating TLEN

--- a/opts.h
+++ b/opts.h
@@ -163,6 +163,7 @@ enum {
 	ARG_SRA_ACC,                // --sra-acc
         ARG_SAM_APPEND_COMMENT,     // --sam-append-comment
         ARG_SAM_OPT_CONFIG,         // --sam-opt-config
+	ARG_K_BEST,                 // --kbest
 };
 
 #endif


### PR DESCRIPTION
### Design

This PR describes a new input argument, `--kbest`, to bowtie2-align. This argument is expected to be used along with the `-k` alignment mode to report up to `k` alignments, with a constraint that all reported alignments share the same alignment score with the primary alignment.