### PR TITLE
cmake: update minimum required version to 3.5 for modern compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
 cmake_policy(SET CMP0048 NEW)
 cmake_policy(SET CMP0005 NEW)


### PR DESCRIPTION
Updated:

```
cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
```

→

```
cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
```

This resolves compatibility issues with CMake ≥3.5 and allows the project to build successfully again.