### PR TITLE
Fix for compressed FASTQ output names with spaces

### DIFF
--- a/bowtie2
+++ b/bowtie2
@@ -537,28 +537,31 @@ if(defined($cap_out)) {
                                 $fn1 = File::Spec->catpath($vol,$base_spec_dir,$fn1);
                                 $fn2 = File::Spec->catpath($vol,$base_spec_dir,$fn2);
                                 $fn1 ne $fn2 || Fail("$fn1\n$fn2\n");
-                                my ($redir1, $redir2) = (">$fn1", ">$fn2");
-                                $redir1 = "| gzip -c $redir1"  if $read_compress{$i} eq "gzip";
-                                $redir1 = "| bzip2 -c $redir1" if $read_compress{$i} eq "bzip2";
-                                $redir1 = "| lz4 -c $redir1" if $read_compress{$i} eq "lz4";
-                                $redir1 = "| zstd -c $redir1" if $read_compress{$i} eq "zstd";
-                                $redir2 = "| gzip -c $redir2"  if $read_compress{$i} eq "gzip";
-                                $redir2 = "| bzip2 -c $redir2" if $read_compress{$i} eq "bzip2";
-                                $redir2 = "| lz4 -c $redir2" if $read_compress{$i} eq "lz4";
-                                $redir2 = "| zstd -c $redir2" if $read_compress{$i} eq "zstd";
+                                my ($redir1, $redir2) = ("$fn1", "$fn2");
+                                $redir1 = ">$redir1" if $read_compress{$i} eq "";
+                                $redir1 = "| gzip -c > \"$redir1\""  if $read_compress{$i} eq "gzip";
+                                $redir1 = "| bzip2 -c > \"$redir1\"" if $read_compress{$i} eq "bzip2";
+                                $redir1 = "| lz4 -c > \"$redir1\"" if $read_compress{$i} eq "lz4";
+                                $redir1 = "| zstd -c > \"$redir1\"" if $read_compress{$i} eq "zstd";
+                                $redir2 = ">$redir2" if $read_compress{$i} eq "";
+                                $redir2 = "| gzip -c > \"$redir2\""  if $read_compress{$i} eq "gzip";
+                                $redir2 = "| bzip2 -c > \"$redir2\"" if $read_compress{$i} eq "bzip2";
+                                $redir2 = "| lz4 -c > \"$redir2\"" if $read_compress{$i} eq "lz4";
+                                $redir2 = "| zstd -c > \"$redir2\"" if $read_compress{$i} eq "zstd";
                                 open($read_fhs{$i}{1}, $redir1) || Fail("Could not open --$i mate-1 output file '$fn1'\n");
                                 open($read_fhs{$i}{2}, $redir2) || Fail("Could not open --$i mate-2 output file '$fn2'\n");
                                 push @fhs_to_close, $read_fhs{$i}{1};
                                 push @fhs_to_close, $read_fhs{$i}{2};
                         } else {
-                                my $redir = ">".File::Spec->catpath($vol,$base_spec_dir,$i."-seqs");
+                                my $redir = File::Spec->catpath($vol,$base_spec_dir,$i."-seqs");
                                 if ($base_fname) {
-                                        $redir = ">$read_fns{$i}";
+                                        $redir = "$read_fns{$i}";
                                 }
-                                $redir = "| gzip -c $redir"  if $read_compress{$i} eq "gzip";
-                                $redir = "| bzip2 -c $redir" if $read_compress{$i} eq "bzip2";
-                                $redir = "| lz4 -c $redir" if $read_compress{$i} eq "lz4";
-                                $redir = "| zstd -c $redir" if $read_compress{$i} eq "zstd";
+                                $redir = ">$redir" if $read_compress{$i} eq "";
+                                $redir = "| gzip -c > \"$redir\""  if $read_compress{$i} eq "gzip";
+                                $redir = "| bzip2 -c > \"$redir\"" if $read_compress{$i} eq "bzip2";
+                                $redir = "| lz4 -c > \"$redir\"" if $read_compress{$i} eq "lz4";
+                                $redir = "| zstd -c > \"$redir\"" if $read_compress{$i} eq "zstd";
                                 open($read_fhs{$i}, $redir) || Fail("Could not open --$i output file '$read_fns{$i}'\n");
                                 push @fhs_to_close, $read_fhs{$i};
                         }


### PR DESCRIPTION
**Problem:** Paths with spaces work fine with options like `--un` and most bowtie2 input/output options, but currently they fail with `--un-gz` and similar options that request compressed FASTQ file output. This is blocking me from safely using these output formats in a pipeline that is otherwise compatible with paths that include spaces.

**Example of a failing command:**
```
 bowtie2 -p 12 \
   -x "output path with spaces/index with spaces" \
   -U "R1 with spaces.fastq.gz" \
   -U "R2 with spaces.fastq.gz" \
   --al-gz "output path with spaces/unpairedal with spaces.fastq.gz" \
   --un-gz "output path with spaces/unpairedun with spaces.fastq.gz" \
   -S "output path with spaces/sam with spaces.sam"
```

**Errors from failing command:**
```
gzip: can't stat: path (path): No such file or directory
gzip: can't stat: with (with): No such file or directory
gzip: can't stat: spaces/unpairedal (spaces/unpairedal): No such file or directory
gzip: can't stat: with (with): No such file or directory
gzip: can't stat: spaces.fastq.gz (spaces.fastq.gz): No such file or directory
gzip: can't stat: path (path): No such file or directory
gzip: can't stat: with (with): No such file or directory
gzip: can't stat: spaces/unpairedun (spaces/unpairedun): No such file or directory
gzip: can't stat: with (with): No such file or directory
gzip: can't stat: spaces.fastq.gz (spaces.fastq.gz): No such file or directory
```

This pull request fixes how the Perl script `bowtie2` handles these filenames, adding quotes when output is piped to compression programs. I've tested that the uncompressed and compressed options work with unpaired and paired input FASTQs with the updated code.