### PR TITLE
Remove redundant DP fill in checkpointed local 16-bit alignment

### DIFF
--- a/aligner_sw.cpp
+++ b/aligner_sw.cpp
@@ -588,7 +588,6 @@ bool SwAligner::align(
 			// 16-bit local
 			flag = 0;
 			if(checkpointed) {
-				best = alignNucleotidesLocalSseI16(flag, false);
 				best = alignGatherLoc16(flag, false);
 				if(flag == 0) {
 					gathered = true;


### PR DESCRIPTION
In `SwAligner::align`, the checkpointed local 16-bit branch calls `alignNucleotidesLocalSseI16()` and then immediately overwrites both its return value and its flag with the results of `alignGatherLoc16()`:

```cpp
if(checkpointed) {
    best = alignNucleotidesLocalSseI16(flag, false);   // discarded on the next line
    best = alignGatherLoc16(flag, false);
```

`alignGatherLoc16()` is self-contained: it rebuilds the query profile, resizes and zeroes its own score vectors, and re-initialises `btdiag_` and `cper_` before performing a complete matrix fill. It consumes no state left behind by `alignNucleotidesLocalSseI16()`, so the first call is a full O(rows x cols) SIMD pass whose result is thrown away.

The three sibling branches (end-to-end 8-bit, end-to-end 16-bit and local 8-bit) each call only their `alignGather*` routine. This restores that pattern for local 16-bit. The extra call dates back to a274eb4 (2012), which introduced the checkpointed DP code.

The branch is reached when `--local` is used on reads at least `--cp-min` (default 2000) long that saturate the 8-bit kernel, so long-read local alignment has been doing roughly twice the DP work it needs to.

### Measured

E. coli index, 300 simulated 5 kb reads at 6% error, single threaded:

| | wall | `DP16ExDps` | `DP16ExCell` |
|---|---|---|---|
| before | 26.15 s | 998 | 25,270,607,392 |
| after | 20.32 s | 499 | 12,635,303,696 |

The 8-bit counters are unchanged (`DP8ExDps` 575, `DP8ExDpSat` 499), and 998 = 2 x 499 confirms the metric was counting each 16-bit DP twice.

SAM output is byte-for-byte identical.

Note that the `SSEMetrics` counters reported by `--met-file` now reflect the actual number of 16-bit DPs performed, so previously inflated `DP16*` values will halve.

### Testing

- `make allall && make simple-test`: PASSED
- `sh scripts/sim/run.sh 4`: identical results to master

On the last point: `scripts/sim/run.pl` never calls `srand`, so each invocation draws a different case set and a single run against a single master run is not comparable. Seeding each case from its index locally and replaying the same set on both:

```
seed=1000  master 0 failures   branch 0 failures
seed=2000  master 3 failures   branch 3 failures
seed=3000  master 0 failures   branch 0 failures
```

The seed=2000 failures are the same on both sides and are pre-existing on master:

```
Assertion failed: (!btdiag_.empty()), function alignGatherLoc8,
file aligner_swsse_loc_u8.cpp, line 913
./bowtie2 --debug --cp-min 2 --cp-ival 2 --local -k 3 -N 0 -L12 --mm --nofw -D 33 \
  --rdg 45.12668347767,6.88195648834403 --rfg 12.4743329218208,19.2451931093081 \
  --gbar 3 --trim3 5 --score-min L,1.53730665644215,1.5980339287002 -r ...
```

That is in the 8-bit gather, which runs earlier in the same `align()` call and is untouched here. Happy to open a separate issue for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)