### PR TITLE
Fix inverted candidate mask test in 8-bit local gather

### DIFF
--- a/aligner_swsse_loc_u8.cpp
+++ b/aligner_swsse_loc_u8.cpp
@@ -672,7 +672,7 @@ TAlScore SwAligner::alignGatherLoc8(int& flag, bool debug) {
 				vh = sse_load_siall(pvHLeft);
 				vtmp = sse_cmpgt_epi8(pvScore[0], vbiasm1);
 				int cmp = sse_movemask_epi8(vtmp);
-				if(cmp != SSE_MASK_ALL) {
+				if(cmp != 0) {
 					// At least one candidate in this mask.  Now iterate
 					// through vm/vh to evaluate individual cells.
 					for(size_t m = 0; m < NWORDS_PER_REG; m++) {
@@ -855,7 +855,7 @@ TAlScore SwAligner::alignGatherLoc8(int& flag, bool debug) {
 			vh = sse_load_siall(pvHLeft);
 			vtmp = sse_cmpgt_epi8(pvScore[0], vbiasm1);
 			int cmp = sse_movemask_epi8(vtmp);
-			if(cmp != SSE_MASK_ALL) {
+			if(cmp != 0) {
 				// At least one candidate in this mask.  Now iterate
 				// through vm/vh to evaluate individual cells.
 				for(size_t m = 0; m < NWORDS_PER_REG; m++) {


### PR DESCRIPTION
Fixes #529.

Both candidate-collection loops in `alignGatherLoc8` build a mask of the lanes whose query profile clears the gap barrier, comment it

```cpp
// At least one candidate in this mask.
```

and then test

```cpp
if(cmp != SSE_MASK_ALL)
```

which is true when at least one lane is *not* a candidate. When every lane in a stripe qualifies, the whole stripe is skipped and its candidates never reach `btdiag_`.

The 16-bit twin, `alignGatherLoc16`, tests `cmp != 0` at both corresponding sites (aligner_swsse_loc_i16.cpp:677 and :860), and the per-lane test that follows is equivalent in both kernels, so the vector-level guards should be too. This makes the 8-bit sites match.

### Why it stayed hidden

A stripe is all-qualifying only when its `NWORDS_PER_REG` rows, which are spaced `iter` apart, all match the same reference character at once: vanishingly unlikely in complex sequence, routine in homopolymers and short-period repeats. Counting stripes with a temporary probe:

| input | `alignGatherLoc8` calls | all-lane stripes | candidate cells dropped |
|---|---|---|---|
| low-complexity reads | 723 | 191,203 | 2,187,803 |
| 50,000 simulated E. coli reads | 44,034 | 0 | 0 |

On real reads every stripe has both a qualifying and a non-qualifying lane, so the two guards agree.

### Impact

When every stripe in a call is all-qualifying, `btdiag_` is left empty and the assertion above `btdiag_.dump()` fires, aborting debug and sanitized builds. That is what `scripts/sim/run.sh` has been hitting intermittently; it draws different random cases each run because `run.pl` never calls `srand`, so the failure looked flaky.

I could not find an input where release output changes: on everything I tried the SAM is identical with and without this patch. So the demonstrated impact is the debug-build abort and the dropped bookkeeping, not missed alignments. I would not want to overstate it.

### Testing

The reproducer in #529 aborts on master and passes here. Also, on this branch:

- `make allall && make simple-test`: PASSED
- `sh scripts/sim/run.sh 4 --no-die-with-child`, three runs: 2000 / 2001 / 2001 cases, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)